### PR TITLE
Add white colour for button background

### DIFF
--- a/src/elements/button.less
+++ b/src/elements/button.less
@@ -935,6 +935,11 @@
   background-color: #FFFFFF;
 }
 
+.ui.white.buttons .button:hover,
+.ui.white.button:hover {
+  background-color: #A4A4A4;
+}
+
 /*--- Black ---*/
 .ui.black.buttons .button,
 .ui.black.button {


### PR DESCRIPTION
This keeps the defaults for the button, but overrides the background colour to make it white.

(I didn't add the newline - that was the github editor)
