### PR TITLE
Added the input element of checkbox to the dom with 0 opacity.

### DIFF
--- a/src/modules/checkbox.less
+++ b/src/modules/checkbox.less
@@ -28,7 +28,7 @@
   vertical-align: middle;
 }
 .ui.checkbox input {
-  visibility: hidden;
+  opacity: 0;
   outline: none;
 }
 


### PR DESCRIPTION
This way the element can participate in the tabindex-ing.

This closes issue #103, but the general "element focusing" issue needs to be addressed in a common manner.
