### PR TITLE
added font-family attribute to button class.

### DIFF
--- a/src/elements/button.less
+++ b/src/elements/button.less
@@ -29,6 +29,7 @@
 
   padding: 0.8em 1.5em;
 
+  font-family: "Helvetica Neue", "Helvetica", Arial;
   font-size: 1rem;
   text-transform: uppercase;
   line-height: 1;


### PR DESCRIPTION
Its absence was causing to lose 3px of width whenever used in a div instead of an input.

This closes issue #114
