### PR TITLE
remove menu item "Getting Started"

### DIFF
--- a/node/src/documents/introduction.html.eco
+++ b/node/src/documents/introduction.html.eco
@@ -14,7 +14,6 @@ type        : 'Semantic'
   <div class="peek">
     <div class="ui vertical pointing secondary menu">
       <a class="active item">Philosophy</a>
-      <a class="item">Getting Started</a>
     </div>
   </div>
 


### PR DESCRIPTION
In [introduction page](http://semantic-ui.com/introduction.html), i clicked menu item "Getting Started", I got a error like this.

```
Cannot read property 'top' of undefined.
```

There is no heading of "Getting Started", so i remove this item.
