### PR TITLE
Blur document.activeElement on $.modal('show')

### DIFF
--- a/src/modules/modal.js
+++ b/src/modules/modal.js
@@ -45,6 +45,7 @@ $.fn.modal = function(parameters) {
         $context     = $(settings.context),
         $otherModals = $allModals.not($modal),
         $closeButton = $modal.find(selector.closeButton),
+        $activeElement = $(document.activeElement),
 
         $dimmer,
 
@@ -143,6 +144,7 @@ $.fn.modal = function(parameters) {
 
         show: function() {
           modal.debug('Showing modal');
+          $activeElement.blur();
           modal.set.type();
           modal.set.position();
           modal.hideAll();


### PR DESCRIPTION
You don't really want to be able to type things into an input which is obscurred by a modal window, so focus should probably be blurred when modal is shown.

---

It might make sense to 'remember' the selected elements and re-focus them on $.modal('hide'), I dunno. I think doing that could pose some potential problems.

I do realize that other frameworks leave this up to the developer to do during the show/hide events -- and that is certainly one solution. However I feel like it's not really a good UX to NOT do this, so it's kind of silly to require a developer to register an event handler for it. Further, it is awkward for MVVM frameworks, because the events emitted by the modal element will most likely end up dealing with a controller, who should not be messing with the DOM at all. Ergo, it seems a simple thing to make this a configurable behaviour, but it probably makes the most sense to just do it all the time.
