### PR TITLE
Invalid json fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     {
       "name" : "Jack Lukic",
       "email": "jacklukic@gmail.com",
-      T"web"  : "http://www.jacklukic.com",
+      "web"  : "http://www.jacklukic.com",
       "role" : "Creator"
     }
   ],
@@ -17,7 +17,5 @@
     "css",
     "framework"
   ],
-  "license" : [
-    "MIT"
-  ]
+  "license" : "MIT"
 }


### PR DESCRIPTION
Removed unicode or escape character so it validates and removed unnecessary array on license.
