### PR TITLE
add an result indicator in ui / element steps group

### DIFF
--- a/src/elements/step.less
+++ b/src/elements/step.less
@@ -291,3 +291,59 @@
 .ui.large.steps .step {
   font-size: 1.25rem;
 }
+
+
+/*******************************
+             Result
+*******************************/
+
+.ui.steps .ui.state {
+  display: inline-block;
+  z-index: 10;
+  position: absolute;
+  background: red;
+  padding: 5px;
+  border-radius: 30px;
+  font-size: 12px;
+  font-weight: 900;
+  background: #444444;
+  border: 3px solid #EEEEEE;
+  color: #FFFFFF;
+  margin: 10px 20px 0 0;
+  i { margin: 0; }
+}
+
+.ui.steps .ui.state.black {
+  background: #5C6166;
+  i { color: #FFFFFF }
+}
+
+.ui.steps .ui.state.green {
+  background: #5BBD72;
+  i { color: #FFFFFF }
+}
+
+.ui.steps .ui.state.red {
+  background: #D95C5C;
+  i { color: #FFFFFF }
+}
+
+.ui.steps .ui.state.blue {
+  background: #6ECFF5;
+  i { color: #FFFFFF }
+}
+
+.ui.steps .ui.state.purple {
+  background: #564F8A;
+  i { color: #FFFFFF }
+}
+
+.ui.steps .ui.state.teal {
+  background: #00B5AD;
+  i { color: #FFFFFF }
+}
+
+.ui.steps .ui.state.orange {
+  background: #E96633;
+  i { color: #FFFFFF }
+}


### PR DESCRIPTION
While working on our local project we found sometimes it needs an indicator about the result of user's last step. thus I added a result indicator which can be used to show it. example:

![2013-10-26 11 07 08](https://f.cloud.github.com/assets/2672307/1412776/c3ae5c78-3deb-11e3-96db-33e2c03422a2.png)

sample usage:

```
<div class="ui.steps">
  <div class="ui.step"> step 1 </div>
  <div class="ui.state"> or </div>
  <div class="ui.step"> step 2 </div>
</div>
```
