### PR TITLE
fixes #303 dropdown icon needs cursor: pointer

### DIFF
--- a/src/modules/dropdown.less
+++ b/src/modules/dropdown.less
@@ -16,6 +16,7 @@
 .ui.dropdown {
   position: relative;
   display: inline-block;
+  cursor: pointer;
 
   line-height: 1;
 
@@ -90,7 +91,6 @@
 .ui.dropdown > .dropdown.icon {
   width: auto;
   margin: 0em 0em 0em 1em;
-  cursor: pointer;
 }
 
 .ui.dropdown > .dropdown.icon:before {
@@ -111,7 +111,6 @@
 ---------------*/
 
 .ui.dropdown > .text {
-  cursor: pointer;
   display: inline-block;
 
   -webkit-transition: color 0.2s ease;
@@ -142,7 +141,6 @@
 }
 
 .ui.dropdown .menu .item {
-  cursor: pointer;
   border: none;
   border-top: 1px solid rgba(0, 0, 0, 0.05);
   height: auto;
@@ -292,7 +290,6 @@
 /* Displays like a select box */
 
 .ui.selection.dropdown {
-  cursor: pointer;
   display: inline-block;
 
   word-wrap: break-word;
@@ -411,7 +408,6 @@
 ---------------*/
 
 .ui.inline.dropdown {
-  cursor: pointer;
   display: inline-block;
   color: inherit;
 }


### PR DESCRIPTION
- [fiddle without this](http://jsfiddle.net/aEDFd/1)
- [fiddle with this](http://jsfiddle.net/aEDFd/)

This uses the HTML from the first sample on [dropdown#usage](http://semantic-ui.com/modules/dropdown.html#/usage).
