### PR TITLE
#343 modal text can't be selected

### DIFF
--- a/src/modules/modal.less
+++ b/src/modules/modal.less
@@ -32,10 +32,10 @@
   -moz-border-radius: 5px;
   border-radius: 5px;
   
-  -webkit-user-select: initial;
-  -moz-user-select: initial;
-  -ms-user-select: initial;
-  user-select: initial;
+  -webkit-user-select: text;
+  -moz-user-select: text;
+  -ms-user-select: text;
+  user-select: text;
 }
 
 


### PR DESCRIPTION
The cause of this is `.ui.dimmer` has `user-select: none`, which by default inherits into their children.  You can override it in children to change that behavior.
