### PR TITLE
Fixed width of .ui.attached.icon.message

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Semantic is a set of specifications for sharing UI elements between developers. 
 
 Semantic is production ready, but is formally "pre-release" until proper build and theming tools are available, and documentation is complete for all components.
 
+The project is under constant development, so be sure to check out our [release notes](https://github.com/jlukic/Semantic-UI/blob/master/RELEASE%20NOTES.md) for recent changes.
+
 [![Flattr This](https://api.flattr.com/button/flattr-badge-large.png)](https://flattr.com/submit/auto?user_id=jlukic&url=https%3A%2F%2Fgithub.com%2Fjlukic%2FSemantic-UI)
 
 ### Bugs and Issues

--- a/src/collections/message.less
+++ b/src/collections/message.less
@@ -219,6 +219,10 @@
   -moz-border-radius: 0em 0em 0.325em 0.325em;
   border-radius: 0em 0em 0.325em 0.325em;
 }
+.ui.attached.icon.message {
+  display: block;
+  width: auto;
+}
 
 
 /*--------------


### PR DESCRIPTION
When attaching an `.icon.message` to another `.message`, the `.icon.message`'s width doesn't match the `.message`'s width. 

Here's a [demo of the issue ](http://jsfiddle.net/overra/Vbr9d/48/) and the fix.
