### PR TITLE
Add social button style for vk.com

### DIFF
--- a/src/elements/button.less
+++ b/src/elements/button.less
@@ -428,7 +428,6 @@
   color: #FFFFFF;
 }
 
-
 /* Pinterest */
 .ui.pinterest.button {
   background-color: #00ACED;
@@ -443,6 +442,19 @@
   color: #FFFFFF;
 }
 
+/* vk.com */
+.ui.vk.button {
+  background-color: #4D7198;
+  color: #FFFFFF;
+}
+.ui.vk.button:hover {
+  background-color: #537AA5;
+  color: #FFFFFF;
+}
+.ui.vk.button:active {
+  background-color: #405E7E;
+  color: #FFFFFF;
+}
 /*--------------
      Icon
 ---------------*/


### PR DESCRIPTION
vk.com is a popular Russian social network which is often used as OAuth2 authentication provider. So, it would be nice to include a button style for it just like it was made for Facebook or Twitter, as vk.com icon is already included in the icons set

Usage example

```
<div class="ui grid">
  <div class="row">
    <div class="ui small fluid vk button">
      <i class="vk icon"></i>
      vk.com
    </div>
  </div>
  <div class="row">
    <div class="ui small fluid facebook button">
      <i class="facebook icon"></i>
      Facebook
    </div>
  </div>
  <div class="row">
    <div class="ui small fluid twitter button">
      <i class="twitter icon"></i>
      Twitter
    </div>
  </div>
</div>
```

Result:
![screen shot 2013-12-06 at 23 50 20](https://f.cloud.github.com/assets/424279/1695608/37a09620-5eb5-11e3-8e49-6219d4d6117f.png)
