### PR TITLE
allow grouped buttons in actions

### DIFF
--- a/src/elements/input.less
+++ b/src/elements/input.less
@@ -286,14 +286,16 @@
   border-bottom-right-radius: 0px !important;
   border-right: none;
 }
-.ui.action.input > .button {
+.ui.action.input > .button,
+.ui.action.input > .buttons, {
   display: table-cell;
 
   border-top-left-radius: 0px;
   border-bottom-left-radius: 0px;
   white-space: nowrap;
 }
-.ui.action.input > .button > .icon {
+.ui.action.input > .button > .icon,
+.ui.action.input > .buttons > .button > .icon {
   display: inline;
   vertical-align: top;
 }


### PR DESCRIPTION
This simple addition allows grouped buttons instead of only a single button next to action input fields.

For example:

```
.ui.action.input
    input(type="text", value="0")
    .ui.icon.buttons
        .ui.button
            i.minus.icon
        .ui.button
            i.plus.icon
```

![image](https://f.cloud.github.com/assets/304283/1708805/888414de-6114-11e3-8822-8c12f882868c.png)
