### PR TITLE
fixing a bug where / got prepended to the tabPath

### DIFF
--- a/build/packaged/javascript/semantic.js
+++ b/build/packaged/javascript/semantic.js
@@ -9972,6 +9972,7 @@ $.fn.sidebar.settings = {
               tabPath   = event.pathNames.join('/') || module.get.initialPath(),
               pageTitle = settings.templates.determineTitle(tabPath) || false
             ;
+            if(tabPath.indexOf('%2F') > -1) tabPath = tabPath.replace('%2F','');
             module.debug('History change event', tabPath, event);
             historyEvent = event;
             if(tabPath !== undefined) {


### PR DESCRIPTION
causing an error where the tab couldn’t be found
