### PR TITLE
Keeping Modal in place

### DIFF
--- a/src/elements/segment.less
+++ b/src/elements/segment.less
@@ -128,6 +128,11 @@
   margin-bottom: 0em;
 }
 
+/* Bound to segment size*/
+.ui.segment > .ui.dimmer {
+  position:absolute;
+}
+
 /*******************************
              Types
 *******************************/

--- a/src/modules/dimmer.less
+++ b/src/modules/dimmer.less
@@ -19,7 +19,7 @@
 
 .ui.dimmer {
   display: none;
-  position: absolute;
+  position: fixed;
   top: 0em !important;
   left: 0em !important;
 

--- a/src/modules/modal.js
+++ b/src/modules/modal.js
@@ -77,7 +77,6 @@ $.fn.modal = function(parameters) {
                 hide     : settings.duration * 1.1
               }
             })
-            .dimmer('add content', $module)
           ;
           $dimmer = $dimmable
             .dimmer('get dimmer')


### PR DESCRIPTION
Moving the modal to a new container is highly undesirable, for example: asp.net update panels depends on DOM contents for collecting its data, moving the modal outside will break its functionality.
