### PR TITLE
Transition: Disable animationEnd callback on transition reset.

### DIFF
--- a/src/modules/transition.js
+++ b/src/modules/transition.js
@@ -148,6 +148,7 @@ $.fn.transition = function() {
 
         reset: function() {
           module.debug('Resetting animation to beginning conditions');
+          $module.off(animationEnd);
           module.restore.conditions();
           module.hide();
           module.remove.animating();


### PR DESCRIPTION
Fixes rare race condition with modals where animationEnd callback on dimmer could fire before modal's one, calling .transition('reset') on modal right before animationEnd event for it arrives, causing module.complete callback to restore incorect conditions, making modal visible when it shouldn't be, causing next modals to misbehave.
