### PR TITLE
Doc was missing forward icon in Media Actions

### DIFF
--- a/server/documents/elements/icon.html.eco
+++ b/server/documents/elements/icon.html.eco
@@ -1181,6 +1181,11 @@ type        : 'UI Element'
         <div class="column"><i class="twitter basic icon"></i> Twitter</div>
         <div class="column"><i class="github basic icon"></i> Github</div>
       </div>
+      <div class="existing code">
+    <i class="facebook basic icon"></i>
+    <i class="twitter basic icon"></i>
+    <i class="github basic icon"></i>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
I used web UI and have no idea why github forces the EOL@EOF.
