### PR TITLE
Prevent menu button color inheritance.

### DIFF
--- a/src/collections/menu.less
+++ b/src/collections/menu.less
@@ -1790,6 +1790,10 @@
 .ui.menu:not(.vertical) .item > .button.labeled > .icon {
   padding-top: 0.6em;
 }
+.ui.menu:not(.vertical) .item .action.input > .button {
+  font-size: 0.8em;
+  padding: 0.55em 0.8em;
+}
 .ui.vertical.menu {
   width: 15rem;
 }
@@ -1805,6 +1809,13 @@
   top: -0.125em;
   padding-bottom: 0.6em;
   padding-top: 0.6em;
+}
+.ui.large.menu:not(.vertical) .item .action.input > .button {
+  font-size: 0.8em;
+  padding: 0.9em;
+}
+.ui.large.menu:not(.vertical) .item .action.input > .button > .icon {
+  padding-top: 0.8em;
 }
 .ui.large.menu .dropdown.item .item {
   font-size: 1rem;


### PR DESCRIPTION
Buttons within .ui.menu, that are styled over anchor (`a`) tag, are colored inappropriately.

This fixes it.
