### PR TITLE
Fixed h-menu label displacement, if it's the first child.

### DIFF
--- a/src/collections/menu.less
+++ b/src/collections/menu.less
@@ -341,6 +341,9 @@
   padding: 0.3em 0.8em;
   vertical-align: baseline;
 }
+.ui.menu:not(.vertical) .item > .label:first-child {
+  margin-left: 0;
+}
 .ui.menu .item > .floating.label {
   padding: 0.3em 0.8em;
 }


### PR DESCRIPTION
If there is a label inside horizontal menu, and it is the first child, remove left margin. Margin should be removed, because it offsets the element from center.

Encountered while attempting to use label as a _notification counter_.

This fixes it.

Example / Test: http://jsfiddle.net/psycketom/mAAn5/
