### PR TITLE
Fix W3C CSS gradients syntax.

### DIFF
--- a/src/collections/menu.less
+++ b/src/collections/menu.less
@@ -549,7 +549,7 @@
     rgba(0, 0, 0, 0.1) 1.5em,
     rgba(0, 0, 0, 0.03) 100%)
   ;
-  background-image: linear-gradient(left,
+  background-image: linear-gradient(to right,
     rgba(0, 0, 0, 0.03) 0%,
     rgba(0, 0, 0, 0.1) 1.5em,
     rgba(0, 0, 0, 0.03) 100%)
@@ -1384,7 +1384,7 @@
     rgba(255, 255, 255, 0.1) 50%,
     rgba(255, 255, 255, 0.03) 100%)
   ;
-  background-image: linear-gradient(left,
+  background-image: linear-gradient(to right,
     rgba(255, 255, 255, 0.03) 0%,
     rgba(255, 255, 255, 0.1) 50%,
     rgba(255, 255, 255, 0.03) 100%)


### PR DESCRIPTION
The official, unprefixed syntax needs "linear-gradient(to [direction], ...)" notation instead of "linear-gradient([direction-from], ...)" from earlier ones.
https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient
