### PR TITLE
fixed add prompt for form.js

### DIFF
--- a/src/modules/behavior/form.js
+++ b/src/modules/behavior/form.js
@@ -226,7 +226,7 @@ $.fn.form = function(fields, parameters) {
         add: {
           prompt: function(field, errors) {
             var
-              $field       = module.get.field(field.identifier),
+              $field       = module.get.field(field),
               $fieldGroup  = $field.closest($group),
               $prompt      = $fieldGroup.find(selector.prompt),
               promptExists = ($prompt.size() !== 0)


### PR DESCRIPTION
This is in reference to issue #541

field.identifier doesn't exist.

it changes the syntax to:

``` javascript
$('form').form('add prompt', 'username', ['that username is taken']);
```
