### PR TITLE
Fixes message attached between top and bottom.

### DIFF
--- a/src/collections/message.less
+++ b/src/collections/message.less
@@ -212,6 +212,10 @@
     0em 0em 0em 1px rgba(0, 0, 0, 0.1) inset
   ;
 }
+.ui.attached + .ui.attached.message:not(.top):not(.bottom) {
+  margin-top: -1px;
+  border-radius: 0em;
+}
 .ui.bottom.attached.message {
   margin-top: -1px;
 


### PR DESCRIPTION
Example & test case: http://jsfiddle.net/psycketom/Gv454/

Basically, it allows messages to be seamlessly attached between top and bottom elements.

Currently, attached message has only a "top attached" and "bottom attached" variation.
### Current

![current](https://f.cloud.github.com/assets/1030080/1968923/8316e8bc-82ea-11e3-8109-3b0363a651ba.png)
### Fixed

![fixed](https://f.cloud.github.com/assets/1030080/1968924/8333af2e-82ea-11e3-98a2-06d3e1e6f212.png)
