### PR TITLE
Fixes bottom attached message bottom margin.

### DIFF
--- a/src/collections/message.less
+++ b/src/collections/message.less
@@ -223,6 +223,9 @@
   -moz-border-radius: 0em 0em 0.325em 0.325em;
   border-radius: 0em 0em 0.325em 0.325em;
 }
+.ui.bottom.attached.message:not(:last-child) {
+  margin-bottom: 1em;
+}
 .ui.attached.icon.message {
   display: block;
   width: auto;


### PR DESCRIPTION
Example & test case: http://jsfiddle.net/psycketom/w5BPQ/

Currently, a message that is "bottom attached" will not leave margin behind, making following inline elements, like button, be undivided from it.

This attempts to fix it.

The `:not(:last-child)` filter is applied, because `.ui.segment > :last-child` was overridden by the more precise selector (or maybe even selector order inside prepacked build). I obeyed applying `!important` to latter selector because it's simply discouraged.

While images are nice to have for PR's, from now on I will rely only on Example & Test Case fiddles... mainly, due to my laziness.

P.S. This fix extends upon #568. The test case, though, is tuned for 0.12.2, yet, remains forward compatible to #568.
