### PR TITLE
Fix occurring with specific transitions

### DIFF
--- a/src/modules/transition.js
+++ b/src/modules/transition.js
@@ -549,7 +549,10 @@ $.fn.transition = function() {
           },
           occuring: function(animation) {
             animation = animation || settings.animation;
-            return ( $module.hasClass(animation) );
+
+            var classes = animation.split(' ');
+
+            return ( $(classes).filter(function(i, value) { return $module.hasClass(value); }).length == classes.length );
           },
           visible: function() {
             return $module.is(':visible');


### PR DESCRIPTION
jQuery hasClass only accepts a single class, if you are using a transition like 'fade in' or 'scale in' this will not work correctly if the classes are out of order (it does happen) e.g. 'in scale' in the class string. This fixes it.
