### PR TITLE
probably an old CSS leftover.

### DIFF
--- a/server/files/stylesheets/semantic.css
+++ b/server/files/stylesheets/semantic.css
@@ -1323,10 +1323,6 @@ body.progress .ui.progress .bar {
     width: auto;
     margin: 0% 30px 0px;
   }
-  #example
-  #example .right.attached.launch {
-    display: none;
-  }
 }
 @media only screen and (max-width : 780px) {
   pre.console {


### PR DESCRIPTION
probably an old CSS leftover, [its](https://github.com/Semantic-Org/Semantic-UI/blob/fea6b4d4bfef05e9918d41946dd17c807bfeaade/server/files/stylesheets/semantic.css#L1327) already replaced [by](https://github.com/Semantic-Org/Semantic-UI/blob/fea6b4d4bfef05e9918d41946dd17c807bfeaade/server/files/stylesheets/semantic.css#L1313):

``` CSS
#example .attached.launch.button {
    display: none;
}
```
