### PR TITLE
Closing a modal throws an error when the transitions module isn't available

### DIFF
--- a/src/modules/modal.js
+++ b/src/modules/modal.js
@@ -305,9 +305,11 @@ $.fn.modal = function(parameters) {
             ;
           }
           $dimmable.dimmer('hide', function() {
-            $module
-              .transition('reset')
-            ;
+            if(settings.transition && $.fn.transition !== undefined && $module.transition('is supported')) {
+              $module
+                .transition('reset')
+              ;
+            }
             module.remove.active();
           });
         },


### PR DESCRIPTION
Due to incompatibility with ember.js I had to disable the transition module. The modal code falls back on javascript animation, which is great, however I noticed that on closing a modal, an error was raised: 

[Error] TypeError: 'undefined' is not a function (evaluating '$module
              .transition('reset')')
    (anonymous function) (modal.js, line 310)
    (anonymous function) (dimmer.js, line 217)
    complete (jquery.js, line 9468)
    fire (jquery.js, line 3049)
    fireWith (jquery.js, line 3161)
    tick (jquery.js, line 8923)
    tick (jquery.js, line 9500)

I modified the call to check if the transition module is available before trying to call transition('reset') which appears to of worked.
