### PR TITLE
mono color inverted menu

### DIFF
--- a/server/documents/collections/menu.html.eco
+++ b/server/documents/collections/menu.html.eco
@@ -562,7 +562,7 @@ type        : 'UI Collection'
   <div class="example">
     <h4 class="ui header">Inverted</h4>
     <p>A menu may have its colors inverted to show greater contrast</p>
-    <div class="ui inverted menu">
+    <div class="ui mono inverted menu">
       <a class="active item">
         <i class="home icon"></i> Home
       </a>
@@ -660,7 +660,7 @@ type        : 'UI Collection'
   </div>
   <div class="another example">
     <p>These colors can also be inverted</p>
-    <div class="ui green inverted menu">
+    <div class="ui green mono inverted menu">
       <a class="active item">
         <i class="home icon"></i> Home
       </a>
@@ -672,7 +672,7 @@ type        : 'UI Collection'
       </a>
     </div>
     <br>
-    <div class="ui red inverted menu">
+    <div class="ui red mono inverted menu">
       <a class="active item">
         <i class="home icon"></i> Home
       </a>
@@ -684,7 +684,7 @@ type        : 'UI Collection'
       </a>
     </div>
     <br>
-    <div class="ui blue inverted menu">
+    <div class="ui blue mono inverted menu">
       <a class="active item">
         <i class="home icon"></i> Home
       </a>
@@ -696,7 +696,7 @@ type        : 'UI Collection'
       </a>
     </div>
     <br>
-    <div class="ui orange inverted menu">
+    <div class="ui orange mono inverted menu">
       <a class="active item">
         <i class="home icon"></i> Home
       </a>
@@ -708,7 +708,7 @@ type        : 'UI Collection'
       </a>
     </div>
     <br>
-    <div class="ui purple inverted menu">
+    <div class="ui purple mono inverted menu">
       <a class="active item">
         <i class="home icon"></i> Home
       </a>
@@ -720,7 +720,7 @@ type        : 'UI Collection'
       </a>
     </div>
     <br>
-    <div class="ui teal inverted menu">
+    <div class="ui teal mono inverted menu">
       <a class="active item">
         <i class="home icon"></i> Home
       </a>

--- a/src/collections/menu.less
+++ b/src/collections/menu.less
@@ -1413,8 +1413,10 @@
 }
 
 /*--- Active ---*/
-.ui.inverted.menu .active.item {
+.ui.inverted.mono.menu .active.item{
   box-shadow: none !important;
+}
+.ui.inverted.menu .active.item {  
   background-color: rgba(255, 255, 255, 0.2);
 }
 .ui.inverted.menu .active.item,


### PR DESCRIPTION
Why not to keep the `box-shadow` on inverted color menus? It looks more consistent on dark backgrounds, may be keep both options by adding a new `.mono` variation: 

``` CSS
.ui.inverted.mono.menu .active.item {
  box-shadow: none !important;
}
.ui.inverted.menu .active.item {
  /*box-shadow: none !important;*/
  background-color: rgba(255, 255, 255, 0.2);
}
```

> Normal 
> ![inverted color](https://f.cloud.github.com/assets/4712046/2240111/cc90b2bc-9c75-11e3-87ab-1663fddac23b.png)
> 
> Mono
> ![mono](https://f.cloud.github.com/assets/4712046/2240106/a6a82e18-9c75-11e3-852e-b37ee92e280e.png)
