### PR TITLE
Fixes bracket match in rule function

### DIFF
--- a/src/modules/behavior/form.js
+++ b/src/modules/behavior/form.js
@@ -403,7 +403,7 @@ $.fn.form = function(fields, parameters) {
               type          = validation.type,
               value         = $.trim($field.val() + ''),
 
-              bracketRegExp = /\[(.*?)\]/i,
+              bracketRegExp = /\[(.*)\]/i,
               bracket       = bracketRegExp.exec(type),
               isValid       = true,
               ancillary,


### PR DESCRIPTION
When adding a custom type e.g. "isValid[\[0-9A-Za-z\]\+]" using form validation module, I found it got the wrong match "[0-9A-Za-z" as the regular expression, so I prefer using greedy match.

And here is the source code:

``` js
var validationRules = {
    username: {
        identifier: 'username',
        rules: [
            type: 'isValid[\[0-9A-Za-z\]\+]',
            ...
        ]
    }
};
$.fn.form.settings.rules.isValid = function (value, reg) {
    var regExp = new RegExp(reg),
        matches = regExp.exec(value);
    return matches && matches[0] === value;
};
```
