### PR TITLE
fix single celled tfoot

### DIFF
--- a/src/collections/table.less
+++ b/src/collections/table.less
@@ -66,7 +66,7 @@
 .ui.table tfoot th:last-child {
   border-radius: 0px 0px 5px 0px;
 }
-.ui.table tfoot th:first-child:last-child {
+.ui.table tfoot th:only-child {
   border-radius: 0px 0px 5px 5px;
 }
 


### PR DESCRIPTION
In the case of a single celled tfoot the `:last-child` overrides the `:first-child` and leaves the table with a sharp bottom-left corner. A good example of this use case would be if you had a button action at the end of the table, similar to the first table example in the docs except without the `segment` class.

```
<table class="ui table">
  <thead>
    <tr><th>Name</th>
    <th>Status</th>
    <th>Notes</th>
  </tr></thead>
  <tbody>
    <tr>
      <td>John</td>
      <td>Approved</td>
      <td>None</td>
    </tr>
    <tr>
      <td>Jamie</td>
      <td>Approved</td>
      <td>Requires call</td>
    </tr>
    <tr>
      <td>Jill</td>
      <td>Denied</td>
      <td>None</td>
    </tr>
  </tbody>
  <tfoot>
    <tr><th colspan="3">
      <div class="ui blue labeled icon button"><i class="user icon"></i> Add User</div>
    </th>
  </tr></tfoot>
</table>
  <tfoot>
    <tr><th></th></tr>
  </tfoot>
</table>
```

There's probably a better way to do this, but it worked for me in my project.
