### PR TITLE
Update step.less

### DIFF
--- a/src/elements/step.less
+++ b/src/elements/step.less
@@ -93,13 +93,22 @@
 }
 .ui.vertical.steps .step:first-child {
   padding: 1em 2em;
+  border-radius:0em;
   border-top-left-radius: 0.3125rem;
   border-top-right-radius: 0.3125rem;
 }
+.ui.vertical.steps .active.step:first-child {
+  border-top-right-radius: 0rem;
+}
 .ui.vertical.steps .step:last-child {
+  border-radius:0em;
   border-bottom-left-radius: 0.3125rem;
   border-bottom-right-radius: 0.3125rem;
 }
+.ui.vertical.steps .active.step:last-child {
+  border-bottom-right-radius: 0rem;
+}
+
 
 /* Arrow */
 .ui.vertical.steps .step:after {


### PR DESCRIPTION
This will fix issue #699 sub issue 1) (see: https://github.com/Semantic-Org/Semantic-UI/issues/699)

This will remove rounded corners in the wrong locations of a vertical step including removing rounded corners when a first/last child is active (the rounded corners do not let the arrow lay flush with the step). This is NOT dealing with the two line step which has been solved, but rather with the oddly rounded corners on active.

Picture of old code's rounded corner:
![2014-03-09 12 44 37 am](https://f.cloud.github.com/assets/6738227/2444543/ebd62802-ae57-11e3-9cb0-a96521720eb3.png)
current code: http://jsfiddle.net/FrHze/

The current arrow definition after the two line step, seems to overlap the rounded corners in a weird way, but now the corners are appropriate whether it will overlap or not. Hopefully this will help a little bit.
