### PR TITLE
update modal list when necessary

### DIFF
--- a/src/modules/modal.js
+++ b/src/modules/modal.js
@@ -219,6 +219,11 @@ $.fn.modal = function(parameters) {
           }
         },
 
+        updateModalList: function() {
+          $otherModals = $module.siblings(selector.modal);
+          $allModals   = $otherModals.add($module);
+        },
+
         toggle: function() {
           if( module.is.active() ) {
             module.hide();
@@ -243,6 +248,8 @@ $.fn.modal = function(parameters) {
             : function(){}
           ;
           if( !module.is.active() ) {
+            module.updateModalList();
+
             if(module.cache === undefined) {
               module.cacheSizes();
             }
@@ -298,6 +305,8 @@ $.fn.modal = function(parameters) {
             ? callback
             : function(){}
           ;
+          module.updateModalList();
+
           if($allModals.filter(':visible').size() <= 1) {
             module.hideDimmer();
           }
@@ -365,6 +374,8 @@ $.fn.modal = function(parameters) {
             ? callback
             : function(){}
           ;
+          module.updateModalList();
+
           if( $allModals.is(':visible') ) {
             module.debug('Hiding all visible modals');
             module.hideDimmer();
@@ -380,6 +391,8 @@ $.fn.modal = function(parameters) {
             ? callback
             : function(){}
           ;
+          module.updateModalList();
+
           if( $otherModals.is(':visible') ) {
             module.debug('Hiding other modals');
             $otherModals


### PR DESCRIPTION
This should fix the problem about modals not being hidden correctly when allowMultiple is false (https://github.com/Semantic-Org/Semantic-UI/issues/412). The modal list is updated when needed.

I don't know much about semantic's code philosophy, so I don't know if I coded it the right way. However that does the job. At worse I hope it will help someone to fix it properly :)
