### PR TITLE
Fixed showing poiting arrow in dropdown

### DIFF
--- a/src/modules/dropdown.less
+++ b/src/modules/dropdown.less
@@ -584,7 +584,7 @@
   -webkit-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
   transform: rotate(45deg);
-  z-index: 2;
+  z-index: 12;
 }
 
 .ui.pointing.dropdown .menu .active.item:first-child {


### PR DESCRIPTION
z-index of pointing arrow had too low value, so it remained hidden under dropdown box.
