### PR TITLE
accordion .first-child selectors now less greedy

### DIFF
--- a/src/modules/accordion.less
+++ b/src/modules/accordion.less
@@ -55,8 +55,8 @@
     background-color 0.2s ease-out
   ;
 }
-.ui.accordion .title:first-child,
-.ui.accordion .accordion .title:first-child {
+.ui.accordion > .title:first-child,
+.ui.accordion .accordion > .title:first-child {
 	border-top: none;
 }
 


### PR DESCRIPTION
This allows wrapping divs around .title/.content without loosing the top borders.
