### PR TITLE
Update modal documentation, set default easing to `easeOutQuad`

### DIFF
--- a/server/documents/modules/modal.html.eco
+++ b/server/documents/modules/modal.html.eco
@@ -415,7 +415,7 @@ type        : 'UI Module'
         <tr>
           <td>easing</td>
           <td>
-            easeOutExpo
+            easeOutQuad
           </td>
           <td>Animation easing is only used if javascript animations are used.</td>
         </tr>


### PR DESCRIPTION
The default modal easing function was updated in cfc99e82503ce2cef5c4d59dd763cf77c934f158 to close #816.
