### PR TITLE
Update document about rating module

### DIFF
--- a/server/documents/modules/rating.html.eco
+++ b/server/documents/modules/rating.html.eco
@@ -215,7 +215,7 @@ type        : 'UI Module'
     <p>All the following <a href="/module.html#/behavior">behaviors</a> can be called using the syntax:</p>
     <div class="code">
     $('.ui.rating')
-      .modal('behavior name', argumentOne, argumentTwo)
+      .rating('behavior name', argumentOne, argumentTwo)
     ;
     </div>
 


### PR DESCRIPTION
The document wrongly stated to use `$(...).modal(...)` to call behaviors.
