### PR TITLE
Replace menu inverted active colors (fixes #720)

### DIFF
--- a/src/collections/menu.less
+++ b/src/collections/menu.less
@@ -1487,42 +1487,42 @@
   background-color: #A1CF64;
 }
 .ui.inverted.green.pointing.menu .active.item:after {
-  background-color: #A1CF64;
+  background-color: #B3D782;
 }
 
 .ui.inverted.red.menu {
   background-color: #D95C5C;
 }
 .ui.inverted.red.pointing.menu .active.item:after {
-  background-color: #F16883;
+  background-color: #DF7C7C;
 }
 
 .ui.inverted.blue.menu {
   background-color: #6ECFF5;
 }
 .ui.inverted.blue.pointing.menu .active.item:after {
-  background-color: #6ECFF5;
+  background-color: #8AD7F6;
 }
 
 .ui.inverted.purple.menu {
   background-color: #564F8A;
 }
 .ui.inverted.purple.pointing.menu .active.item:after {
-  background-color: #564F8A;
+  background-color: #7771A0;
 }
 
 .ui.inverted.orange.menu {
   background-color: #F05940;
 }
 .ui.inverted.orange.pointing.menu .active.item:after {
-  background-color: #F05940;
+  background-color: #F27966;
 }
 
 .ui.inverted.teal.menu {
   background-color: #00B5AD;
 }
 .ui.inverted.teal.pointing.menu .active.item:after {
-  background-color: #00B5AD;
+  background-color: #33C3BC;
 }
 
 


### PR DESCRIPTION
This fix changes the background-color of the :after element for inverted pointing menu items to match the rendered active overlay color of the item. This fixes #720.
