### PR TITLE
Fixes and enhancements to src/Gruntfile.js

### DIFF
--- a/src/Gruntfile.js
+++ b/src/Gruntfile.js
@@ -20,7 +20,19 @@ module.exports = function(grunt) {
       'copy:file',
 
       // auto prefix outputted file
-      'autoprefixer:prefixFile'
+      'autoprefixer:prefixFile',
+
+      // creates minified js of outputted file if it is js
+      'newer:uglify:minifyOutput',
+
+      // creates minified css of outputted file if it is css
+      'newer:cssmin:minifyOutput',
+
+      // create concatenated css release if outputted file is css
+      'newer:concat:createCSSPackage',
+
+      // create concatenated js release if outputted file is js
+      'newer:concat:createJSPackage'
     ],
 
     resetTasks = [
@@ -296,6 +308,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-clear');
   grunt.loadNpmTasks('grunt-contrib-concat');
+  grunt.loadNpmTasks('grunt-newer');
 
   // css
   grunt.loadNpmTasks('grunt-contrib-cssmin');

--- a/src/package.json
+++ b/src/package.json
@@ -15,6 +15,7 @@
     "grunt-contrib-less": "~0.7.0",
     "grunt-contrib-concat": "~0.3.0",
     "grunt-clear": "~0.2.1",
-    "grunt-autoprefixer": "~0.4.0"
+    "grunt-autoprefixer": "~0.4.0",
+    "grunt-newer": "~0.7.0"
   }
 }


### PR DESCRIPTION
I fixed the following issues:
- string path replacement does not work on Windows when paths are written with forward slashes
- .variables and .overrides are located in themes/ not definitions/
- grunt watch does not detect changes to .variables and .overrides

And added fast minification and packaging to the grunt watch task (only for modified files). I find this very useful because I usually only include the packaged CSS file in my project and this allows me to quickly make and test theme changes.

Please review. Thanks!
