### PR TITLE
Fix the background color of an inverted menu

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -1212,13 +1212,14 @@
 .ui.inverted.menu .link.item:hover,
 .ui.inverted.menu a.item:hover,
 .ui.inverted.menu .dropdown.item:hover {
-  background-color: rgba(255, 255, 255, 0.1);
+  background-color: rgba(255, 255, 255, 0.1) !important;
 }
 .ui.inverted.menu a.item:hover,
 .ui.inverted.menu .item > a:hover,
 .ui.inverted.menu .item .menu a.item:hover,
 .ui.inverted.menu .item .menu .link.item:hover {
   color: rgba(255, 255, 255, 1);
+  background-color: rgba(255, 255, 255, 0.1);
 }
 
 /*--- Down ---*/
@@ -1244,11 +1245,11 @@
 
 /*--- Pointers ---*/
 .ui.inverted.pointing.menu .active.item:after {
-  background-color: #5B5B5B;
+  background-color: #5B5B5B !important;
   box-shadow: none;
 }
 .ui.inverted.pointing.menu .active.item:hover:after {
-  background-color: #4A4A4A;
+  background-color: #4A4A4A !important;
 }
 
 


### PR DESCRIPTION
Fix the background color of the active pointer in an vertical inverted menu and the color when hovering an active.

It seems to conflict whit the normal menu (non-inverted) and particularly like at the line 417.
I also didn't look if the secondary menu is also affected.

The problem doesn't seem to affect the master version.
