### PR TITLE
add integer value range validation

### DIFF
--- a/src/modules/behavior/form.js
+++ b/src/modules/behavior/form.js
@@ -730,6 +730,33 @@ $.fn.form.settings = {
         urlRegExp = /(ftp|http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?/
       ;
       return urlRegExp.test(value);
+    },
+    integer: function(value, range) {
+      var
+        intRegExp = /^\-?\d+$/,
+        _min,
+        _max
+      ;
+      var _min, _max;
+      if (range === undefined || range == '' || range == '..') {
+      } else if (range.indexOf('..') == -1) {
+        if (intRegExp.test(range)) {
+          _min = _max = range - 0;
+        }
+      } else {
+        var r = range.split('..', 2);
+        if (intRegExp.test(r[0])) {
+          _min = r[0] - 0;
+        }
+        if (intRegExp.test(r[1])) {
+          _max = r[1] - 0;
+        }
+      }
+      return (
+        intRegExp.test(value) &&
+        (_min === undefined || value >= _min) &&
+        (_max === undefined || value <= _max)
+      );
     }
   }
 


### PR DESCRIPTION
This gives the ability to add validation for integer values.
- type: "integer" - no range validation
- type: integer[RANGE] where RANGE can be:
  - NUM - only allow the single value
  - MIN.. - validate minimum only
  - ..MAX - validate maximum only
  - MIN..MAX - validate min and max
  - .. - no min or max
  - empty - no min or max

Positive and negative numbers are accepted, no decimals or commas.  If RANGE is specified where MIN is greater than MAX then no values will be accepted.  If MIN or MAX is not a valid integer it is ignored.

This is related to issue #970
