### PR TITLE
Fix table.column width calculation

### DIFF
--- a/src/collections/table.less
+++ b/src/collections/table.less
@@ -317,6 +317,10 @@
   Column Count
 ---------------*/
 
+.ui.column.table {
+  table-layout: fixed;  
+}
+
 .ui.two.column.table td {
   width: 50%;
 }


### PR DESCRIPTION
When using tables with specific table widths, percentages are calculated correctly but since the padding is being ignored, the columns don't get the correct width.

You can see here: http://jsfiddle.net/ms2hkyeg/

Congratz for this great framework, looking forward 1.0.0 release!
