### PR TITLE
add style to all text based input types

### DIFF
--- a/rtl/less/collections/form.less
+++ b/rtl/less/collections/form.less
@@ -64,6 +64,7 @@
 
 
 .ui.form textarea,
+.ui.form input[type="color"],
 .ui.form input[type="date"],
 .ui.form input[type="datetime"],
 .ui.form input[type="datetime-local"],
@@ -83,6 +84,7 @@
 }
 
 .ui.form textarea,
+.ui.form input[type="color"],
 .ui.form input[type="date"],
 .ui.form input[type="datetime"],
 .ui.form input[type="datetime-local"],
@@ -204,6 +206,7 @@
         Focus
 ---------------------*/
 
+.ui.form input[type="color"]:focus,
 .ui.form input[type="date"]:focus,
 .ui.form input[type="datetime"]:focus,
 .ui.form input[type="datetime-local"]:focus,
@@ -262,6 +265,7 @@
 }
 
 .ui.form .fields.error .field textarea,
+.ui.form .fields.error .field input[type="color"],
 .ui.form .fields.error .field input[type="date"],
 .ui.form .fields.error .field input[type="datetime"],
 .ui.form .fields.error .field input[type="datetime-local"],
@@ -276,6 +280,7 @@
 .ui.form .fields.error .field input[type="url"],
 .ui.form .fields.error .field input[type="week"],
 .ui.form .field.error textarea,
+.ui.form .field.error input[type="color"],
 .ui.form .field.error input[type="date"],
 .ui.form .field.error input[type="datetime"],
 .ui.form .field.error input[type="datetime-local"],
@@ -304,6 +309,7 @@
 }
 
 .ui.form .field.error textarea:focus,
+.ui.form .field.error input[type="color"]:focus,
 .ui.form .field.error input[type="date"]:focus,
 .ui.form .field.error input[type="datetime"]:focus,
 .ui.form .field.error input[type="datetime-local"]:focus,
@@ -487,6 +493,7 @@
   color: #FFFFFF;
 }
 .ui.inverted.form .field.error textarea,
+.ui.inverted.form .field.error input[type="color"],
 .ui.inverted.form .field.error input[type="date"],
 .ui.inverted.form .field.error input[type="datetime"],
 .ui.inverted.form .field.error input[type="datetime-local"],
@@ -728,6 +735,7 @@
   font-size: 0.875em;
 }
 .ui.small.form textarea,
+.ui.small.form input[type="color"],
 .ui.small.form input[type="date"],
 .ui.small.form input[type="datetime"],
 .ui.small.form input[type="datetime-local"],

--- a/src/collections/form.less
+++ b/src/collections/form.less
@@ -64,6 +64,7 @@
 
 
 .ui.form textarea,
+.ui.form input[type="color"],
 .ui.form input[type="date"],
 .ui.form input[type="datetime"],
 .ui.form input[type="datetime-local"],
@@ -83,6 +84,7 @@
 }
 
 .ui.form textarea,
+.ui.form input[type="color"],
 .ui.form input[type="date"],
 .ui.form input[type="datetime"],
 .ui.form input[type="datetime-local"],
@@ -219,6 +221,7 @@
         Focus
 ---------------------*/
 
+.ui.form input[type="color"]:focus,
 .ui.form input[type="date"]:focus,
 .ui.form input[type="datetime"]:focus,
 .ui.form input[type="datetime-local"]:focus,
@@ -278,6 +281,7 @@
 }
 
 .ui.form .fields.error .field textarea,
+.ui.form .fields.error .field input[type="color"],
 .ui.form .fields.error .field input[type="date"],
 .ui.form .fields.error .field input[type="datetime"],
 .ui.form .fields.error .field input[type="datetime-local"],
@@ -292,6 +296,7 @@
 .ui.form .fields.error .field input[type="url"],
 .ui.form .fields.error .field input[type="week"],
 .ui.form .field.error textarea,
+.ui.form .field.error input[type="color"],
 .ui.form .field.error input[type="date"],
 .ui.form .field.error input[type="datetime"],
 .ui.form .field.error input[type="datetime-local"],
@@ -321,6 +326,7 @@
 }
 
 .ui.form .field.error textarea:focus,
+.ui.form .field.error input[type="color"]:focus,
 .ui.form .field.error input[type="date"]:focus,
 .ui.form .field.error input[type="datetime"]:focus,
 .ui.form .field.error input[type="datetime-local"]:focus,
@@ -506,6 +512,7 @@
   color: #FFFFFF;
 }
 .ui.inverted.form .field.error textarea,
+.ui.inverted.form .field.error input[type="color"],
 .ui.inverted.form .field.error input[type="date"],
 .ui.inverted.form .field.error input[type="datetime"],
 .ui.inverted.form .field.error input[type="datetime-local"],
@@ -746,6 +753,7 @@
   font-size: 0.875em;
 }
 .ui.small.form textarea,
+.ui.small.form input[type="color"],
 .ui.small.form input[type="date"],
 .ui.small.form input[type="datetime"],
 .ui.small.form input[type="datetime-local"],


### PR DESCRIPTION
In my HTML5 app I found that some of my form fields did not have Semantic styling applied to them (<input type="time"/> for example).  This pull request is the result of reviewing MDN documentation on input types, and adding style for text based inputs.  Except for width:100%, style was not applied to input[type="range"] since it is a slider (at least on Firefox/Ubuntu).

Additionally all selector rules were alphabetized.  I've only made changes to form.less in rtl/ and src/.  I have not been able to get Grunt working, plus modifying the build directory with minified files would likely conflict with any other CSS change.
