### PR TITLE
Add font to textarea

### DIFF
--- a/rtl/less/elements/input.less
+++ b/rtl/less/elements/input.less
@@ -25,6 +25,9 @@
 
   color: rgba(0, 0, 0, 0.7);
 }
+.ui.input textarea {
+  font-family: "Helvetica Neue", "Helvetica", Arial;
+}
 .ui.input input {
   width: 100%;
   font-family: "Helvetica Neue", "Helvetica", Arial;

--- a/src/elements/input.less
+++ b/src/elements/input.less
@@ -25,6 +25,9 @@
 
   color: rgba(0, 0, 0, 0.7);
 }
+.ui.input textarea {
+  font-family: "Helvetica Neue", "Helvetica", Arial;
+}
 .ui.input input {
   width: 100%;
   font-family: "Helvetica Neue", "Helvetica", Arial;


### PR DESCRIPTION
I noticed on some of my forms that textarea looked weird next to input type="text".  This change sets font-family for textarea to make it more consistent with other text inputs.
