### PR TITLE
[Modules] All module templates should escape unsafe values

### DIFF
--- a/src/modules/popup.js
+++ b/src/modules/popup.js
@@ -11,6 +11,17 @@
 
 ;(function ($, window, document, undefined) {
 
+function encodeHtml(html) {
+  if(!html) {
+    return html;
+  }
+  return String(html)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
 $.fn.popup = function(parameters) {
   var
     $allModules     = $(this),
@@ -155,8 +166,8 @@ $.fn.popup = function(parameters) {
           if(html || content || title) {
             if(!html) {
               html = settings.template({
-                title   : title,
-                content : content
+                title   : encodeHtml(title),
+                content : encodeHtml(content)
               });
             }
             $popup = $('<div/>')


### PR DESCRIPTION
Hello, everyone!

We use this awesome Semantic-UI library at our project http://konfettin.ru. 
Thanks a lot for your work!

We faced such problem as XSS vulnerability in popups.
For example, we have such element:

``` html
<a href="/some/link" title="&lt;script&gt;alert('Hello, world!');&lt;script&gt;">Link</a>
```

If this element is used with Semantic-UI popup module and popup is shown you see alert. The problem is when you get attribute value with `$('selector').attr('title')` it returns decoded HTML and it is not safe to use it without any processing.

I've found in popup docs [here](http://semantic-ui.com/modules/popup.html#/usage) that for exacly HTML output in popup `data-html` property should be used otherwise any developer expects to see safe encoded text.
