### PR TITLE
fix popup template for header

### DIFF
--- a/rtl/uncompressed/modules/popup.js
+++ b/rtl/uncompressed/modules/popup.js
@@ -845,7 +845,7 @@ $.fn.popup.settings = {
     var html = '';
     if(typeof text !== undefined) {
       if(typeof text.title !== undefined && text.title) {
-        html += '<div class="header">' + text.title + '</div class="header">';
+        html += '<div class="header">' + text.title + '</div>';
       }
       if(typeof text.content !== undefined && text.content) {
         html += '<div class="content">' + text.content + '</div>';

--- a/src/modules/popup.js
+++ b/src/modules/popup.js
@@ -845,7 +845,7 @@ $.fn.popup.settings = {
     var html = '';
     if(typeof text !== undefined) {
       if(typeof text.title !== undefined && text.title) {
-        html += '<div class="header">' + text.title + '</div class="header">';
+        html += '<div class="header">' + text.title + '</div>';
       }
       if(typeof text.content !== undefined && text.content) {
         html += '<div class="content">' + text.content + '</div>';


### PR DESCRIPTION
The html template for the popup header (title) contains class on the closing tag.  Though the HTML processors might allow (ignore) this, it causes a failure with XHTML.
