### PR TITLE
Call settings.message instead module.message

### DIFF
--- a/src/modules/search.js
+++ b/src/modules/search.js
@@ -344,7 +344,7 @@ $.fn.search = function(source, parameters) {
               }
             }
             else {
-              html = module.message(error.noResults, 'empty');
+              html = module.message(settings.noResults, 'empty');
             }
             $.proxy(settings.onResults, $module)(response);
             return html;


### PR DESCRIPTION
I've got `module.message is underfined` when tried to search with no results.

Testcase (any query): http://codepen.io/unknownexception/pen/Atnmq
