### PR TITLE
Instruct bower-rails to keep SemanticUI's fonts and images

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,9 @@
   "homepage"    : "http://www.semantic-ui.com",
   "main": [
     "build/packaged/css/semantic.css",
-    "build/packaged/javascript/semantic.js"
+    "build/packaged/javascript/semantic.js",
+    "build/packaged/fonts/*",
+    "build/packaged/images/*"
   ],
   "author": {
     "name" : "Jack Lukic",


### PR DESCRIPTION
`bower-rails` cleans up whichever file is not included on bower's main directive as per [their readme](https://github.com/42dev/bower-rails#bower-main-files). 

This was causing fonts and images to be missing when using them together. That's is addressed on this PR.
