### PR TITLE
Three/Four Column Doubling Rows on Mobile

### DIFF
--- a/src/definitions/collections/grid.less
+++ b/src/definitions/collections/grid.less
@@ -896,12 +896,12 @@
   .ui[class*="three column"].doubling:not(.stackable).grid > .row > .column,
   .ui[class*="three column"].doubling:not(.stackable).grid > .column,
   .ui.grid > [class*="three column"].doubling:not(.stackable).row > .column {
-    width: @twoColumn !important;
+    width: @oneColumn !important;
   }
   .ui[class*="four column"].doubling:not(.stackable).grid > .row > .column,
   .ui[class*="four column"].doubling:not(.stackable).grid > .column,
   .ui.grid > [class*="four column"].doubling:not(.stackable).row > .column {
-    width: @twoColumn !important;
+    width: @oneColumn !important;
   }
   .ui[class*="five column"].doubling:not(.stackable).grid > .row > .column,
   .ui[class*="five column"].doubling:not(.stackable).grid > .column,


### PR DESCRIPTION
Three column and four column doubling rows become 1 column on mobile devices.

Hopefully I did this right. Never created pull request before. 
