### PR TITLE
Fixed npm - replaced hidden module with _module variable

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -596,8 +596,16 @@ module.exports = function(grunt) {
         options: {
           patterns: [
             {
-              match: /\$.fn.\w+/g,
-              replacement: 'module.exports'
+              match: /\$\.fn\.\w+\s*=\s*function\(parameters\)\s*{/g,
+              replacement: 'module.exports = function(parameters) {\n  var _module = module;\n'
+            },
+            {
+              match: /\$\.fn\.\w+\.settings/g,
+              replacement: '_module.exports.settings'
+            },
+            {
+              match: /\$\.fn\.\w+\.settings\s*=/g,
+              replacement: 'module.exports.settings ='
             },
             {
               match: /jQuery/g,

--- a/npm/modules/accordion.js
+++ b/npm/modules/accordion.js
@@ -12,6 +12,8 @@
 ;(function ($, window, document, undefined) {
 
 module.exports = function(parameters) {
+  var _module = module;
+
   var
     $allModules     = $(this),
 
@@ -27,8 +29,8 @@ module.exports = function(parameters) {
     .each(function() {
       var
         settings        = ( $.isPlainObject(parameters) )
-          ? $.extend(true, {}, module.exports.settings, parameters)
-          : $.extend({}, module.exports.settings),
+          ? $.extend(true, {}, _module.exports.settings, parameters)
+          : $.extend({}, _module.exports.settings),
 
         className       = settings.className,
         namespace       = settings.namespace,

--- a/npm/modules/behavior/api.js
+++ b/npm/modules/behavior/api.js
@@ -12,6 +12,8 @@
 ;(function ( $, window, document, undefined ) {
 
   $.api = module.exports = function(parameters) {
+  var _module = module;
+
 
     var
       settings       = $.extend(true, {}, $.api.settings, parameters),
@@ -524,6 +526,8 @@
 
   // handle DOM attachment to API functionality
   module.exports = function(parameters) {
+  var _module = module;
+
     $(this)
       .each(function(){
         var
@@ -532,8 +536,8 @@
           selector = $(this).selector || '',
 
           settings = ( $.isFunction(parameters) )
-            ? $.extend(true, {}, $.api.settings, module.exports.settings, { stateContext: this, success: parameters })
-            : $.extend(true, {}, $.api.settings, module.exports.settings, { stateContext: this}, parameters),
+            ? $.extend(true, {}, $.api.settings, _module.exports.settings, { stateContext: this, success: parameters })
+            : $.extend(true, {}, $.api.settings, _module.exports.settings, { stateContext: this}, parameters),
           module
         ;
         module = {

--- a/npm/modules/behavior/colorize.js
+++ b/npm/modules/behavior/colorize.js
@@ -12,8 +12,10 @@
 ;(function ( $, window, document, undefined ) {
 
   module.exports = function(parameters) {
+  var _module = module;
+
     var
-      settings        = $.extend(true, {}, module.exports.settings, parameters),
+      settings        = $.extend(true, {}, _module.exports.settings, parameters),
       // hoist arguments
       moduleArguments = arguments || false
     ;

--- a/npm/modules/behavior/form.js
+++ b/npm/modules/behavior/form.js
@@ -11,12 +11,12 @@
 
 ;(function ( $, window, document, undefined ) {
 
-module.exports = function(fields, parameters) {
+$.fn.form = function(fields, parameters) {
   var
     $allModules     = $(this),
 
-    settings        = $.extend(true, {}, module.exports.settings, parameters),
-    validation      = $.extend({}, module.exports.settings.defaults, fields),
+    settings        = $.extend(true, {}, _module.exports.settings, parameters),
+    validation      = $.extend({}, _module.exports.settings.defaults, fields),
 
     namespace       = settings.namespace,
     metadata        = settings.metadata,
@@ -282,7 +282,7 @@ module.exports = function(fields, parameters) {
                 .html(errors[0])
               ;
               if(!promptExists) {
-                if(settings.transition && module.exports !== undefined && $module.transition('is supported')) {
+                if(settings.transition && $.fn.transition !== undefined && $module.transition('is supported')) {
                   module.verbose('Displaying error with css transition', settings.transition);
                   $prompt.transition(settings.transition + ' in', settings.duration);
                 }
@@ -318,7 +318,7 @@ module.exports = function(fields, parameters) {
             ;
             if(settings.inline && $prompt.is(':visible')) {
               module.verbose('Removing prompt for field', field);
-              if(settings.transition && module.exports !== undefined && $module.transition('is supported')) {
+              if(settings.transition && $.fn.transition !== undefined && $module.transition('is supported')) {
                 $prompt.transition(settings.transition + ' out', settings.duration, function() {
                   $prompt.remove();
                 });

--- a/npm/modules/behavior/state.js
+++ b/npm/modules/behavior/state.js
@@ -12,9 +12,11 @@
 ;(function ( $, window, document, undefined ) {
 
 module.exports = function(parameters) {
+  var _module = module;
+
   var
     $allModules     = $(this),
-    settings        = $.extend(true, {}, module.exports.settings, parameters),
+    settings        = $.extend(true, {}, _module.exports.settings, parameters),
 
     moduleSelector  = $allModules.selector || '',
 

--- a/npm/modules/chatroom.js
+++ b/npm/modules/chatroom.js
@@ -12,6 +12,8 @@
 ;(function ($, window, document, undefined) {
 
 module.exports = function(parameters) {
+  var _module = module;
+
   var
     $allModules    = $(this),
     moduleSelector = $allModules.selector || '',
@@ -27,7 +29,7 @@ module.exports = function(parameters) {
   $(this)
     .each(function() {
       var
-        settings  = $.extend(true, {}, module.exports.settings, parameters),
+        settings  = $.extend(true, {}, _module.exports.settings, parameters),
 
         className = settings.className,
         namespace = settings.namespace,

--- a/npm/modules/checkbox.js
+++ b/npm/modules/checkbox.js
@@ -12,6 +12,8 @@
 ;(function ( $, window, document, undefined ) {
 
 module.exports = function(parameters) {
+  var _module = module;
+
   var
     $allModules    = $(this),
     moduleSelector = $allModules.selector || '',
@@ -28,7 +30,7 @@ module.exports = function(parameters) {
   $allModules
     .each(function() {
       var
-        settings        = $.extend(true, {}, module.exports.settings, parameters),
+        settings        = $.extend(true, {}, _module.exports.settings, parameters),
 
         className       = settings.className,
         namespace       = settings.namespace,

--- a/npm/modules/dimmer.js
+++ b/npm/modules/dimmer.js
@@ -12,6 +12,8 @@
 ;(function ( $, window, document, undefined ) {
 
 module.exports = function(parameters) {
+  var _module = module;
+
   var
     $allModules     = $(this),
 
@@ -29,8 +31,8 @@ module.exports = function(parameters) {
     .each(function() {
       var
         settings        = ( $.isPlainObject(parameters) )
-          ? $.extend(true, {}, module.exports.settings, parameters)
-          : $.extend({}, module.exports.settings),
+          ? $.extend(true, {}, _module.exports.settings, parameters)
+          : $.extend({}, _module.exports.settings),
 
         selector        = settings.selector,
         namespace       = settings.namespace,
@@ -155,7 +157,7 @@ module.exports = function(parameters) {
               : function(){}
             ;
             module.set.dimmed();
-            if(settings.on != 'hover' && settings.useCSS && module.exports !== undefined && $dimmer.transition('is supported')) {
+            if(settings.on != 'hover' && settings.useCSS && $.fn.transition !== undefined && $dimmer.transition('is supported')) {
               $dimmer
                 .transition({
                   animation : settings.transition + ' in',
@@ -190,7 +192,7 @@ module.exports = function(parameters) {
               ? callback
               : function(){}
             ;
-            if(settings.on != 'hover' && settings.useCSS && module.exports !== undefined && $dimmer.transition('is supported')) {
+            if(settings.on != 'hover' && settings.useCSS && $.fn.transition !== undefined && $dimmer.transition('is supported')) {
               module.verbose('Hiding dimmer with css');
               $dimmer
                 .transition({

--- a/npm/modules/dropdown.js
+++ b/npm/modules/dropdown.js
@@ -11,6 +11,8 @@
 ;(function ( $, window, document, undefined ) {
 
 module.exports = function(parameters) {
+  var _module = module;
+
     var
     $allModules    = $(this),
     $document      = $(document),
@@ -31,8 +33,8 @@ module.exports = function(parameters) {
     .each(function() {
       var
         settings          = ( $.isPlainObject(parameters) )
-          ? $.extend(true, {}, module.exports.settings, parameters)
-          : $.extend({}, module.exports.settings),
+          ? $.extend(true, {}, _module.exports.settings, parameters)
+          : $.extend({}, _module.exports.settings),
 
         className       = settings.className,
         metadata        = settings.metadata,
@@ -605,7 +607,7 @@ module.exports = function(parameters) {
               if(settings.transition == 'none') {
                 callback();
               }
-              else if(module.exports !== undefined && $module.transition('is supported')) {
+              else if($.fn.transition !== undefined && $module.transition('is supported')) {
                 $currentMenu
                   .transition({
                     animation : settings.transition + ' in',
@@ -655,7 +657,7 @@ module.exports = function(parameters) {
             callback = callback || function(){};
             if(module.is.visible($currentMenu) ) {
               module.verbose('Doing menu hide animation', $currentMenu);
-              if(module.exports !== undefined && $module.transition('is supported')) {
+              if($.fn.transition !== undefined && $module.transition('is supported')) {
                 $currentMenu
                   .transition({
                     animation : settings.transition + ' out',

--- a/npm/modules/modal.js
+++ b/npm/modules/modal.js
@@ -12,6 +12,8 @@
 ;(function ( $, window, document, undefined ) {
 
 module.exports = function(parameters) {
+  var _module = module;
+
   var
     $allModules = $(this),
     $window     = $(window),
@@ -39,8 +41,8 @@ module.exports = function(parameters) {
     .each(function() {
       var
         settings    = ( $.isPlainObject(parameters) )
-          ? $.extend(true, {}, module.exports.settings, parameters)
-          : $.extend({}, module.exports.settings),
+          ? $.extend(true, {}, _module.exports.settings, parameters)
+          : $.extend({}, _module.exports.settings),
 
         selector        = settings.selector,
         className       = settings.className,
@@ -71,7 +73,7 @@ module.exports = function(parameters) {
         initialize: function() {
           module.verbose('Initializing dimmer', $context);
 
-          if(module.exports === undefined) {
+          if($.fn.dimmer === undefined) {
             module.error(error.dimmer);
             return;
           }
@@ -285,7 +287,7 @@ module.exports = function(parameters) {
               callback();
             };
 
-            if(settings.transition && module.exports !== undefined && $module.transition('is supported')) {
+            if(settings.transition && $.fn.transition !== undefined && $module.transition('is supported')) {
               module.debug('Showing modal with css animations');
               $module
                 .transition(settings.transition + ' in', settings.duration, transitionCallback)
@@ -334,7 +336,7 @@ module.exports = function(parameters) {
             ;
           }
           $dimmable.dimmer('hide', function() {
-            if(settings.transition && module.exports !== undefined && $module.transition('is supported')) {
+            if(settings.transition && $.fn.transition !== undefined && $module.transition('is supported')) {
               $module
                 .transition('reset')
               ;
@@ -366,7 +368,7 @@ module.exports = function(parameters) {
             callback();
           };
 
-          if(settings.transition && module.exports !== undefined && $module.transition('is supported')) {
+          if(settings.transition && $.fn.transition !== undefined && $module.transition('is supported')) {
             module.debug('Hiding modal with css animations');
             $module
               .transition(settings.transition + ' out', settings.duration, transitionCallback)

--- a/npm/modules/nag.js
+++ b/npm/modules/nag.js
@@ -12,6 +12,8 @@
 ;(function ($, window, document, undefined) {
 
 module.exports = function(parameters) {
+  var _module = module;
+
   var
     $allModules     = $(this),
     moduleSelector  = $allModules.selector || '',
@@ -27,7 +29,7 @@ module.exports = function(parameters) {
   $(this)
     .each(function() {
       var
-        settings        = $.extend(true, {}, module.exports.settings, parameters),
+        settings        = $.extend(true, {}, _module.exports.settings, parameters),
 
         className       = settings.className,
         selector        = settings.selector,

--- a/npm/modules/popup.js
+++ b/npm/modules/popup.js
@@ -12,6 +12,8 @@
 ;(function ($, window, document, undefined) {
 
 module.exports = function(parameters) {
+  var _module = module;
+
   var
     $allModules     = $(this),
     $document       = $(document),
@@ -31,8 +33,8 @@ module.exports = function(parameters) {
     .each(function() {
       var
         settings        = ( $.isPlainObject(parameters) )
-          ? $.extend(true, {}, module.exports.settings, parameters)
-          : $.extend({}, module.exports.settings),
+          ? $.extend(true, {}, _module.exports.settings, parameters)
+          : $.extend({}, _module.exports.settings),
 
         selector        = settings.selector,
         className       = settings.className,
@@ -288,7 +290,7 @@ module.exports = function(parameters) {
             $module
               .addClass(className.visible)
             ;
-            if(settings.transition && module.exports !== undefined && $module.transition('is supported')) {
+            if(settings.transition && $.fn.transition !== undefined && $module.transition('is supported')) {
               $popup
                 .transition(settings.transition + ' in', settings.duration, function() {
                   module.bind.close();
@@ -310,7 +312,7 @@ module.exports = function(parameters) {
           hide: function(callback) {
             callback = callback || function(){};
             module.debug('Hiding pop-up');
-            if(settings.transition && module.exports !== undefined && $module.transition('is supported')) {
+            if(settings.transition && $.fn.transition !== undefined && $module.transition('is supported')) {
               $popup
                 .transition(settings.transition + ' out', settings.duration, function() {
                   module.reset();

--- a/npm/modules/rating.js
+++ b/npm/modules/rating.js
@@ -12,6 +12,8 @@
 ;(function ($, window, document, undefined) {
 
 module.exports = function(parameters) {
+  var _module = module;
+
   var
     $allModules     = $(this),
     moduleSelector  = $allModules.selector || '',
@@ -28,8 +30,8 @@ module.exports = function(parameters) {
     .each(function() {
       var
         settings        = ( $.isPlainObject(parameters) )
-          ? $.extend(true, {}, module.exports.settings, parameters)
-          : $.extend({}, module.exports.settings),
+          ? $.extend(true, {}, _module.exports.settings, parameters)
+          : $.extend({}, _module.exports.settings),
 
         namespace       = settings.namespace,
         className       = settings.className,

--- a/npm/modules/search.js
+++ b/npm/modules/search.js
@@ -11,7 +11,7 @@
 
 ;(function ($, window, document, undefined) {
 
-module.exports = function(source, parameters) {
+$.fn.search = function(source, parameters) {
   var
     $allModules     = $(this),
     moduleSelector  = $allModules.selector || '',
@@ -27,7 +27,7 @@ module.exports = function(source, parameters) {
   $(this)
     .each(function() {
       var
-        settings        = $.extend(true, {}, module.exports.settings, parameters),
+        settings        = $.extend(true, {}, _module.exports.settings, parameters),
 
         className       = settings.className,
         selector        = settings.selector,

--- a/npm/modules/shape.js
+++ b/npm/modules/shape.js
@@ -12,6 +12,8 @@
 ;(function ( $, window, document, undefined ) {
 
 module.exports = function(parameters) {
+  var _module = module;
+
   var
     $allModules     = $(this),
     $body           = $('body'),
@@ -29,7 +31,7 @@ module.exports = function(parameters) {
     .each(function() {
       var
         moduleSelector  = $allModules.selector || '',
-        settings        = $.extend(true, {}, module.exports.settings, parameters),
+        settings        = $.extend(true, {}, _module.exports.settings, parameters),
 
         // internal aliases
         namespace     = settings.namespace,

--- a/npm/modules/sidebar.js
+++ b/npm/modules/sidebar.js
@@ -12,6 +12,8 @@
 ;(function ( $, window, document, undefined ) {
 
 module.exports = function(parameters) {
+  var _module = module;
+
   var
     $allModules    = $(this),
     $body          = $('body'),
@@ -32,8 +34,8 @@ module.exports = function(parameters) {
     .each(function() {
       var
         settings        = ( $.isPlainObject(parameters) )
-          ? $.extend(true, {}, module.exports.settings, parameters)
-          : $.extend({}, module.exports.settings),
+          ? $.extend(true, {}, _module.exports.settings, parameters)
+          : $.extend({}, _module.exports.settings),
 
         selector        = settings.selector,
         className       = settings.className,

--- a/npm/modules/tab.js
+++ b/npm/modules/tab.js
@@ -12,9 +12,11 @@
 ;(function ($, window, document, undefined) {
 
   module.exports = function(parameters) {
+  var _module = module;
+
 
     var
-      settings        = $.extend(true, {}, module.exports.settings, parameters),
+      settings        = $.extend(true, {}, _module.exports.settings, parameters),
 
       $module         = $(this),
       $tabs           = $(settings.context).find(settings.selector.tabs),

--- a/npm/modules/transition.js
+++ b/npm/modules/transition.js
@@ -11,7 +11,7 @@
 
 ;(function ( $, window, document, undefined ) {
 
-module.exports = function() {
+$.fn.transition = function() {
   var
     $allModules     = $(this),
     moduleSelector  = $allModules.selector || '',
@@ -298,7 +298,7 @@ module.exports = function() {
             instance.displayType = displayType;
           },
           transitionExists: function(animation, exists) {
-            module.exports.exists[animation] = exists;
+            $.fn.transition.exists[animation] = exists;
             module.verbose('Saving existence of transition', animation, exists);
           },
           conditions: function() {
@@ -383,11 +383,11 @@ module.exports = function() {
           settings: function(animation, duration, complete) {
             // single settings object
             if(typeof animation == 'object') {
-              return $.extend(true, {}, module.exports.settings, animation);
+              return $.extend(true, {}, _module.exports.settings, animation);
             }
             // all arguments provided
             else if(typeof complete == 'function') {
-              return $.extend({}, module.exports.settings, {
+              return $.extend({}, _module.exports.settings, {
                 animation : animation,
                 complete  : complete,
                 duration  : duration
@@ -395,31 +395,31 @@ module.exports = function() {
             }
             // only duration provided
             else if(typeof duration == 'string' || typeof duration == 'number') {
-              return $.extend({}, module.exports.settings, {
+              return $.extend({}, _module.exports.settings, {
                 animation : animation,
                 duration  : duration
               });
             }
             // duration is actually settings object
             else if(typeof duration == 'object') {
-              return $.extend({}, module.exports.settings, duration, {
+              return $.extend({}, _module.exports.settings, duration, {
                 animation : animation
               });
             }
             // duration is actually callback
             else if(typeof duration == 'function') {
-              return $.extend({}, module.exports.settings, {
+              return $.extend({}, _module.exports.settings, {
                 animation : animation,
                 complete  : duration
               });
             }
             // only animation provided
             else {
-              return $.extend({}, module.exports.settings, {
+              return $.extend({}, _module.exports.settings, {
                 animation : animation
               });
             }
-            return module.exports.settings;
+            return _module.exports.settings;
           },
 
           displayType: function() {
@@ -431,7 +431,7 @@ module.exports = function() {
           },
 
           transitionExists: function(animation) {
-            return module.exports.exists[animation];
+            return $.fn.transition.exists[animation];
           },
 
           animationName: function() {
@@ -753,7 +753,7 @@ module.exports = function() {
   ;
 };
 
-module.exports.exists = {};
+$.fn.transition.exists = {};
 
 module.exports.settings = {
 

--- a/npm/modules/video.js
+++ b/npm/modules/video.js
@@ -11,6 +11,8 @@
 ;(function ($, window, document, undefined) {
 
 module.exports = function(parameters) {
+  var _module = module;
+
 
   var
     $allModules     = $(this),
@@ -31,8 +33,8 @@ module.exports = function(parameters) {
     .each(function() {
       var
         settings        = ( $.isPlainObject(parameters) )
-          ? $.extend(true, {}, module.exports.settings, parameters)
-          : $.extend({}, module.exports.settings),
+          ? $.extend(true, {}, _module.exports.settings, parameters)
+          : $.extend({}, _module.exports.settings),
 
         selector        = settings.selector,
         className       = settings.className,


### PR DESCRIPTION
The npm packages do not work because the module exports variable is hidden by the locally defined module  variable within the functions - module.exports.settings is undefined. This fix adds a _module alias. A better but more involved fix is to not use module as local variable name, but that requires changing all the js files.
