### PR TITLE
[Beta] Correcting some styles for search selection dropdowns in menus

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -279,6 +279,12 @@
   width: 100%;
 }
 
+/* Menu Selection Dropdown */
+.ui.menu .ui.selection.dropdown.item {
+  background: none;
+  border: none;
+}
+
 /*--------------
      Labels
 ---------------*/
@@ -1155,7 +1161,9 @@
 }
 
 .ui.inverted.menu .item,
-.ui.inverted.menu .item > a:not(.ui) {
+.ui.inverted.menu .item > a:not(.ui),
+.ui.inverted.menu .ui.selection.dropdown.item>input.search,
+.ui.inverted.menu .ui.selection.visible.dropdown.item>.text:not(.default)  {
   color: @invertedTextColor;
 }
 
@@ -1209,7 +1217,9 @@
 }
 
 /*--- Active ---*/
-.ui.inverted.menu .active.item {
+.ui.inverted.menu .active.item,
+.ui.inverted.menu .ui.selection.dropdown.item>input.search:focus,
+.ui.inverted.menu .ui.selection.active.dropdown.item>.text:not(.default) {
   box-shadow: none !important;
   background: @invertedActiveBackground;
   color: @invertedActiveColor !important;
@@ -1217,6 +1227,9 @@
 .ui.inverted.vertical.menu .item .menu .active.item {
   background: @invertedSubMenuActiveBackground;
   color: @invertedSubMenuActiveColor;
+}
+.ui.inverted.menu .ui.selection.dropdown.item>input.search:focus + .text {
+  color: rgba(255, 255, 255, 0.7) !important;
 }
 
 /*--- Pointers ---*/


### PR DESCRIPTION
Hi There!

I was trying to add a <a href="http://beta.semantic-ui.com/modules/dropdown.html#search-selection">search selection dropdown</a> to an inverted menu and I noticed some of the dropdown background and text style for .ui.selection.dropdown was overriding the menu background and text colors. See this example: http://jsfiddle.net/vaL8phbw/8/

I took a crack at modifying menu.less to get the colors to be correct. I wasn't 100% sure whether these should go into menu.less or dropdown.less, but I put them in menu.less.

All suggestions & modifications welcome! Or let me know if I'm missing something and this isn't actually a bug.

Thanks!

Marc
