### PR TITLE
Fix stackable card top margin

### DIFF
--- a/src/definitions/views/card.less
+++ b/src/definitions/views/card.less
@@ -721,6 +721,9 @@ a.ui.card:hover,
   .ui.stackable.cards {
     display: block !important;
   }
+  .ui.stackable.cards > .card:first-of-type {
+    margin-top: 0;
+  }
   .ui.stackable.cards > .card {
     display: block !important;
     height: auto !important;


### PR DESCRIPTION
Stackable card created a top margin which make the layout inconsistent.
Demo: http://jsfiddle.net/indream/0k65a33w/
You can comment the css to view the bug.
