### PR TITLE
Fixed 'match' rule of form validation.

### DIFF
--- a/src/modules/behavior/form.js
+++ b/src/modules/behavior/form.js
@@ -714,8 +714,8 @@ $.fn.form.settings = {
       if($form.find('#' + fieldIdentifier).size() > 0) {
         matchingValue = $form.find('#' + fieldIdentifier).val();
       }
-      else if($form.find('[name=' + fieldIdentifier +']').size() > 0) {
-        matchingValue = $form.find('[name=' + fieldIdentifier + ']').val();
+      else if($form.find('[name="' + fieldIdentifier +'"]').size() > 0) {
+        matchingValue = $form.find('[name="' + fieldIdentifier + '"]').val();
       }
       else if( $form.find('[data-validate="'+ fieldIdentifier +'"]').size() > 0 ) {
         matchingValue = $form.find('[data-validate="'+ fieldIdentifier +'"]').val();


### PR DESCRIPTION
[Demo]
- Problem: http://jsfiddle.net/seonggwang/m0sq4qL2/2/
- Solution: http://jsfiddle.net/seonggwang/m0sq4qL2/4/

Problem occurred when parameter contains bracket in 'match'.
Like "match[user[password]]"

![Firefox Console](https://cloud.githubusercontent.com/assets/1792867/4788075/201c8fe0-5db5-11e4-8ec3-78d4b4706f36.png)
