### PR TITLE
Allow tabular menu to support multiple segments

### DIFF
--- a/src/collections/menu.less
+++ b/src/collections/menu.less
@@ -755,6 +755,7 @@
   position: relative;
   z-index: 2;
 }
+.ui.tabular.menu + .attached.segment,
 .ui.tabular.menu ~ .bottom.attached.segment {
   margin: 1px 0px 0px 1px;
 }


### PR DESCRIPTION
You might want to have multiple segments up against a tabular menu, like this:

```
<div class="ui top attached tabular menu">
    <a class="active item">
        Tab 1
    </a>
    <a class="item">
        Tab 2
    </a>
</div>
<div class="ui attached segment">
    I am the content...
</div>
<div class="ui bottom attached warning message">
    <i class="warning icon"></i>
    Don't forget the bean bag!
</div>
```

This change will make it possible. Although the tilde (`~`) rule...

```
.ui.tabular.menu ~ .bottom.attached.segment
```

...probably could be removed.
