### PR TITLE
disable button appropriately

### DIFF
--- a/src/definitions/modules/checkbox.js
+++ b/src/definitions/modules/checkbox.js
@@ -203,18 +203,18 @@ $.fn.checkbox = function(parameters) {
           }
         },
 
-        disable: function() {
+        enable: function() {
           module.debug('Enabling checkbox functionality');
-          $module.addClass(className.disabled);
-          $input.removeProp('disabled');
-          $.proxy(settings.onDisabled, $input.get())();
+          $module.removeClass(className.disabled);
+          $input.prop('disabled',false);
+          $.proxy(settings.onEnabled, $input.get())();
         },
 
-        enable: function() {
+        disable: function() {
           module.debug('Disabling checkbox functionality');
-          $module.removeClass(className.disabled);
+          $module.addClass(className.disabled);
           $input.prop('disabled', 'disabled');
-          $.proxy(settings.onEnabled, $input.get())();
+          $.proxy(settings.onDisabled, $input.get())();
         },
 
         check: function() {


### PR DESCRIPTION
The 'disable' property of Checkbox can't remove by '.removeProp()'
use .prop('disable',false) instead.

[.removeProp() api documentation:](http://api.jquery.com/removeprop/)

```
Note: Do not use this method to remove native properties such as checked, disabled, or selected. 
This will remove the property completely and, once removed, cannot be added again to element. 
Use .prop() to set these properties to false instead.
```
