### PR TITLE
fix missing closing td in kitchensink

### DIFF
--- a/examples/kitchensink.html
+++ b/examples/kitchensink.html
@@ -2964,7 +2964,7 @@ $(document)
     </tr>
     <tr class="positive">
       <td>User 2</td>
-      <td>
+      <td></td>
       <td>Data</td>
     </tr>
     <tr class="negative">


### PR DESCRIPTION
Missing `</td>` might throw error on compile.
