### PR TITLE
Fixes double border of pointing menu attached to segment

### DIFF
--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -83,11 +83,6 @@
     Loose Coupling
 --------------------*/
 
-/* Menu */
-.ui.pointing.menu + .ui.attached.segment {
-  top: 1px;
-}
-
 /* Header */
 .ui.inverted.segment > .ui.header {
   color: @white;


### PR DESCRIPTION
A demo of the bug and how it should look after fixed can
be found at http://jsfiddle.net/davialexandre/cww15fon/1/
