### PR TITLE
default to schema agnostic font urls

### DIFF
--- a/src/themes/default/globals/site.variables
+++ b/src/themes/default/globals/site.variables
@@ -15,7 +15,7 @@
 @googleFontSizes   : '400,700,400italic,700italic';
 @googleSubset      : 'latin';
 
-@googleProtocol    : 'http://';
+@googleProtocol    : '//';
 @googleFontRequest : '@{googleFontName}:@{googleFontSizes}&subset=@{googleSubset}';
 
 /*-------------------


### PR DESCRIPTION
In order to avoid "insecure content" warnings on https hosted sites using semantic ui, `googleProtocol` should default to the schema agnostic "//". This is supported in all modern browsers and avoids the need to switch protocols manually and therefore to rebuild the dist files just in order to deploy on a https page.

btw: great work on semantic ui - I really like it so far!
