### PR TITLE
remove irc channel from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Key Features
 
 * **Want to learn about Semantic?** [Request an Invite](https://docs.google.com/forms/d/1hI1z136sXLkTQKtsv8SIvjjAvzpH77YzMQKrU-P8GAc/viewform?usp=send_form) to join [our Slack chatroom](http://semanticui.slack.com) for support and project discussions
 * **Have a bug?** Make a test case by forking this [jsfiddle](http://jsfiddle.net/efp8z6Ln/), then submit a [bug on GitHub](https://github.com/Semantic-Org/Semantic-UI/issues)
-* **Having issues with your code?** Join our [IRC chat](http://webchat.freenode.net/?randomnick=1&channels=%23semantic-ui&prompt=1&uio=OT10cnVlJjExPTEyMwb9), submit a question on [StackOverflow](http://www.stackoverflow.com) or ask our [Google Group](https://groups.google.com/forum/#!forum/semantic-ui)
+* **Having issues with your code?** Submit a question on [StackOverflow](http://www.stackoverflow.com) or ask our [Google Group](https://groups.google.com/forum/#!forum/semantic-ui)
 * **Looking for a specific integration like Dart, Wordpress, Angular, or Rails?** Check out our [integration page](https://github.com/Semantic-Org/Semantic-UI/wiki/Integration)
 
 


### PR DESCRIPTION
The irc channel is being abandoned (lack of use, unanswered questions, etc.).  Most people come, ask a question, and leave after a few minutes.  It should be removed from anywhere else it's mentioned (if anywhere).

If more people joined it'd be a different story, but you need a certain number of active users to make a channel valuable, and that didn't happen.
