### PR TITLE
makes font loading protocol-relative

### DIFF
--- a/src/themes/default/globals/site.variables
+++ b/src/themes/default/globals/site.variables
@@ -15,7 +15,7 @@
 @googleFontSizes   : '400,700,400italic,700italic';
 @googleSubset      : 'latin';
 
-@googleProtocol    : 'http://';
+@googleProtocol    : '//';
 @googleFontRequest : '@{googleFontName}:@{googleFontSizes}&subset=@{googleSubset}';
 
 /*-------------------


### PR DESCRIPTION
Shouldn't matter whether the site is loaded over HTTPS or not, based on http://www.paulirish.com/2010/the-protocol-relative-url/ we can eliminate the headaches by using protocol-relative URLs.
