### PR TITLE
googleProtocol variable

### DIFF
--- a/src/themes/default/globals/site.variables
+++ b/src/themes/default/globals/site.variables
@@ -15,7 +15,7 @@
 @googleFontSizes   : '400,700,400italic,700italic';
 @googleSubset      : 'latin';
 
-@googleProtocol    : 'http://';
+@googleProtocol    : '//';
 @googleFontRequest : '@{googleFontName}:@{googleFontSizes}&subset=@{googleSubset}';
 
 /*-------------------


### PR DESCRIPTION
We don’t need to specify protocol for good font, because it will only
work on http:// and not on https://.

Just meet this error: 

```
Mixed Content: The page at 'https://<site>/’ was loaded over HTTPS, but requested an insecure stylesheet 'http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic&subset=latin'. This request has been blocked; the content must be served over HTTPS.
```
