### PR TITLE
Fix @focusBackground

### DIFF
--- a/src/themes/default/elements/input.variables
+++ b/src/themes/default/elements/input.variables
@@ -82,7 +82,7 @@
 
 /* Focus */
 @focusBorderColor: @selectedBorderColor;
-@focusBackground: '';
+@focusBackground: @background;
 @focusColor: @hoveredTextColor;
 @focusBoxShadow: none;
 


### PR DESCRIPTION
Intuitively I would expect the focus background to be equal to @background here, which defaults to white.
I would imagine that the behaviour in [this example](http://semantic-ui.com/elements/input.html#inverted) is incorrect when putting the cursor inside the input field, since the input becomes invisible.
