### PR TITLE
Bug fix #1554, modified .ui.segment.attached to fix content pane bleeding

### DIFF
--- a/dist/semantic.css
+++ b/dist/semantic.css
@@ -12293,10 +12293,8 @@ ol.ui.horizontal.list li:before,
   top: 0px;
   bottom: 0px;
   margin: 0em -1px;
-  width: -webkit-calc(100% +  2px );
-  width: calc(100% +  2px );
-  max-width: -webkit-calc(100% +  2px );
-  max-width: calc(100% +  2px );
+  width: 100%;  
+  max-width: 100%;
   border-radius: 0px;
   box-shadow: none;
   border: 1px solid #d4d4d5;


### PR DESCRIPTION
Minor fix for issue #1554, as described by @mxth, here: http://jsfiddle.net/6murnr7n/20/


Changing `.ui.segment.attached { width: calc(100% + 2px) }` to `.ui.segment.attached { width:100% }` thus ensuring there's no bleed on the content pane and it aligns itself to the nav perfectly.

Cheers,
Rishav S