### PR TITLE
Form Reset + Serialize

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -163,6 +163,8 @@ $.fn.form = function(fields, parameters) {
 
                switch (type) {
                  case 'hidden':
+                 case 'select-one':
+                 case 'select-multiple':
                    $parent.is('.ui.dropdown') && $parent.dropdown('restore defaults');
                    break;
                  case 'checkbox':

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -60,7 +60,7 @@ $.fn.form = function(fields, parameters) {
         initialize: function() {
           module.verbose('Initializing form validation', $module, validation, settings);
           module.bindEvents();
-          module.setDefaults();
+          module.set.field.defaults();
           module.instantiate();
         },
 
@@ -128,26 +128,6 @@ $.fn.form = function(fields, parameters) {
               $(this)
                 .on(inputEvent + eventNamespace, module.event.field.change)
               ;
-            })
-          ;
-        },
-
-        setDefaults: function() {
-          $field
-            .each(function () {
-              var
-                $field = $(this),
-                type = $field.prop('type')
-              ;
-
-              switch (type) {
-              	case 'checkbox':
-              	case 'radio':
-                  $field.data('defaultValue', $field.is(':checked'));
-                  break;
-                default:
-                  $field.data('defaultValue', $field.val());
-              }
             })
           ;
         },
@@ -433,6 +413,61 @@ $.fn.form = function(fields, parameters) {
               .removeClass(className.success)
               .addClass(className.error)
             ;
+          },
+          field: {
+          	defaults: function () {
+              $field
+                .each(function () {
+                  var
+                    $field = $(this),
+                    type = $field.prop('type')
+                  ;
+
+                  switch (type) {
+                    case 'checkbox':
+                    case 'radio':
+                      $field.data('defaultValue', $field.is(':checked'));
+                      break;
+                    default:
+                      $field.data('defaultValue', $field.val());
+                  }
+                })
+              ;
+          	},
+          	value: function (field, value) {
+              var data = {};
+              data[field] = value;
+              return module.set.field.values.call(element, data);
+          	},
+            values: function (data) {
+              if ($.isEmptyObject(data))
+                return;
+
+              $.each(data, function (key, value) {
+              	if (typeof value === 'object')
+                  return;
+
+                var
+                  $identifier = module.get.field(key),
+                  type = $identifier.prop('type'),
+                  $parent = $identifier.parent()
+                ;
+
+                if (!$identifier.length)
+                  return;
+
+                switch (type) {
+                  case 'checkbox':
+                    $identifier.parent('.ui.checkbox').checkbox(value ? 'check' : 'uncheck');
+                    break;
+                  case 'radio':
+                    $identifier.filter('[value="' + value + '"]').parent('.ui.checkbox').checkbox('check');
+                    break;
+                  default:
+                    $parent.is('.ui.dropdown') ? $parent.dropdown('set selected', value) : $identifier.val(value);
+                }
+              });
+            }
           }
         },
 

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -141,7 +141,8 @@ $.fn.form = function(fields, parameters) {
               ;
 
               switch (type) {
-                case 'checkbox':
+              	case 'checkbox':
+              	case 'radio':
                   $field.data('defaultValue', $field.is(':checked'));
                   break;
                 default:
@@ -167,7 +168,8 @@ $.fn.form = function(fields, parameters) {
                  case 'select-multiple':
                    $parent.is('.ui.dropdown') && $parent.dropdown('restore defaults');
                    break;
-                 case 'checkbox':
+               	case 'checkbox':
+               	case 'radio':
                    $parent.is('.ui.checkbox') && $parent.checkbox(defaultValue ? 'check' : 'uncheck');
                    break;
                  default:
@@ -177,6 +179,32 @@ $.fn.form = function(fields, parameters) {
                 $field.parents('.field').removeClass(settings.className.error);
             })
           ;
+        },
+
+        serialize: function () {
+          var data = {};
+
+          $field
+            .each(function () {
+              var
+                $field = $(this),
+                type = $field.prop('type'),
+                name = $field.prop('name')
+              ;
+
+              switch (type) {
+                case 'checkbox':
+                case 'radio':
+                  if ($field.is(':checked'))
+                    data[name] = $field.val();
+                    break;
+                default:
+                  data[name] = $field.val();
+              }
+            })
+          ;
+
+          return data;
         },
 
         removeEvents: function() {

--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -46,6 +46,7 @@ $.fn.form = function(fields, parameters) {
         $message   = $(this).find(selector.message),
         $prompt    = $(this).find(selector.prompt),
         $submit    = $(this).find(selector.submit),
+        $reset     = $(this).find(selector.reset),
 
         formErrors = [],
 
@@ -59,6 +60,7 @@ $.fn.form = function(fields, parameters) {
         initialize: function() {
           module.verbose('Initializing form validation', $module, validation, settings);
           module.bindEvents();
+          module.setDefaults();
           module.instantiate();
         },
 
@@ -115,6 +117,7 @@ $.fn.form = function(fields, parameters) {
           ;
           // attach submit events
           module.attachEvents($submit, 'submit');
+          module.attachEvents($reset, 'reset');
 
           $field
             .each(function() {
@@ -125,6 +128,51 @@ $.fn.form = function(fields, parameters) {
               $(this)
                 .on(inputEvent + eventNamespace, module.event.field.change)
               ;
+            })
+          ;
+        },
+
+        setDefaults: function() {
+          $field
+            .each(function () {
+              var
+                $field = $(this),
+                type = $field.prop('type')
+              ;
+
+              switch (type) {
+                case 'checkbox':
+                  $field.data('defaultValue', $field.is(':checked'));
+                  break;
+                default:
+                  $field.data('defaultValue', $field.val());
+              }
+            })
+          ;
+        },
+
+        reset: function() {
+          $field
+            .each(function () {
+              var
+                $field = $(this),
+                $parent = $field.parent(),
+                type = $field.prop('type'),
+                defaultValue = $field.data('defaultValue')
+              ;
+
+               switch (type) {
+                 case 'hidden':
+                   $parent.is('.ui.dropdown') && $parent.dropdown('restore defaults');
+                   break;
+                 case 'checkbox':
+                   $parent.is('.ui.checkbox') && $parent.checkbox(defaultValue ? 'check' : 'uncheck');
+                   break;
+                 default:
+                   $field.val(defaultValue);
+                }
+
+                $field.parents('.field').removeClass(settings.className.error);
             })
           ;
         },
@@ -670,7 +718,8 @@ $.fn.form.settings = {
     checkbox: 'input[type="checkbox"], input[type="radio"]',
     input   : 'input',
     prompt  : '.prompt.label',
-    submit  : '.submit'
+    submit  : '.submit',
+    reset   : '.reset'
   },
 
   className : {


### PR DESCRIPTION
Implementing a reset functionality to form module

I implemented this instead of using form native due to Semantic modules, such as checkbox and dropdown (select), plus to avoid having to do "return false" on submitting the form via Ajax.

As instance of module occurs, it will set a data value (defaultValue) to all field identifiers passed through.
As reset is called, it will look these fields and set their value to their respective defaults.
May need a bit more polishing, but works as expected.

Manual call: $('.ui.form').form('reset');

Working example: http://jsfiddle.net/mktm/y5zopezh/
