### PR TITLE
Prevent default components being merged with user-defined components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-dist/
 node_modules/
 test/coverage/
 coverage/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+dist/
 node_modules/
 test/coverage/
 coverage/

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -118,7 +118,7 @@ var
       runSetup = true;
       config = defaults;
     }
-    config = extend(true, {}, defaults, config);
+    config = extend(false, {}, defaults, config);
 
     // shorthand
     base    = config.base;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -864,7 +864,7 @@ gulp.task('install', 'Set-up project for first time', function () {
         };
       }
       if(answers.rtl) {
-        json.rtl = answers.rtl;
+        json.rtl = answers.rtl == "yes" ? true : false;
       }
       if(answers.site) {
         json.paths.source.site = answers.site + '/';


### PR DESCRIPTION
Hello,

Currently when you have only a few components defined in your `semantic.json` file, it also merges the other components on top of the selected components from defaults.

The issue with it is, if you want to compile a custom semantic build without all of the components, it's not possible. This is due to the deep copy been set to `true` for `extend`.

Setting it to `false` allows you to compile a semantic build with only the components you want.