### PR TITLE
Put popups over modals so modals can have popups.

### DIFF
--- a/src/themes/default/modules/popup.variables
+++ b/src/themes/default/modules/popup.variables
@@ -6,7 +6,7 @@
        Element
 --------------------*/
 
-@zIndex: 900;
+@zIndex: 1100;
 @background: @white;
 
 @maxWidth: 250px;


### PR DESCRIPTION
Without this, modals cannot have popups because they will be obfuscated due to popups currently having a `z-index` of 900, beneath the modal's z-index of `1000`.