### PR TITLE
Update icons to support Font Awesome 4.3

### DIFF
--- a/src/themes/default/elements/icon.overrides
+++ b/src/themes/default/elements/icon.overrides
@@ -10,17 +10,9 @@
  */
 
 /*
- *  Font Awesome 4.0.3
- *  the iconic font designed for Bootstrap
- *  ------------------------------------------------------------------------------
- *  The full suite of pictographic icons, examples, and documentation can be
- *  found at http://fon.io.  Stay up to date on Twitter at
- *  http://twitter.com/fon.
- *
- *  License
- *  ------------------------------------------------------------------------------
- *  - The Font Awesome font is licensed under SIL OFL 1.1 -
- *    http://scripts.sil.org/OFL
+ * Font Awesome 4.3.0 by @davegandy - http://fontawesome.io - @fontawesome
+ * License - http://fontawesome.io/license (Font: SIL OFL 1.1, CSS: MIT License)
+ */
 
 /*******************************
 
@@ -53,7 +45,8 @@ for instance `lemon icon` not `lemon outline icon` since there is only one lemon
 i.icon.search:before { content: "\f002"; }
 i.icon.mail.outline:before { content: "\f003"; }
 i.icon.external.link:before { content: "\f08e"; }
-i.icon.wifi:before { content: "\f012"; }
+i.icon.signal:before { content: "\f012"; }
+i.icon.wifi:before { content: "\f1eb"; }
 i.icon.setting:before { content: "\f013"; }
 i.icon.home:before { content: "\f015"; }
 i.icon.inbox:before { content: "\f01c"; }
@@ -69,7 +62,10 @@ i.icon.settings:before { content: "\f085"; }
 i.icon.trophy:before { content: "\f091"; }
 i.icon.payment:before { content: "\f09d"; }
 i.icon.feed:before { content: "\f09e"; }
+i.icon.alarm:before { content: "\f0f3"; }
 i.icon.alarm.outline:before { content: "\f0a2"; }
+i.icon.alarm.slash:before { content: "\f1f6"; }
+i.icon.alarm.slash.outline:before { content: "\f1f7"; }
 i.icon.tasks:before { content: "\f0ae"; }
 i.icon.cloud:before { content: "\f0c2"; }
 i.icon.lab:before { content: "\f0c3"; }
@@ -77,7 +73,6 @@ i.icon.mail:before { content: "\f0e0"; }
 i.icon.idea:before { content: "\f0eb"; }
 i.icon.dashboard:before { content: "\f0e4"; }
 i.icon.sitemap:before { content: "\f0e8"; }
-i.icon.alarm:before { content: "\f0f3"; }
 i.icon.terminal:before { content: "\f120"; }
 i.icon.code:before { content: "\f121"; }
 i.icon.protect:before { content: "\f132"; }
@@ -91,6 +86,12 @@ i.icon.history:before { content: "\f1da"; }
 i.icon.options:before { content: "\f1de"; }
 i.icon.comment.outline:before { content: "\f0e5"; }
 i.icon.comments.outline:before { content: "\f0e6"; }
+i.icon.teletype:before { content: "\f1e4"; }
+i.icon.copyright:before { content: "\f1f9"; }
+i.icon.at:before { content: "\f1fa"; }
+i.icon.eyedropper:before { content: "\f1fb"; }
+i.icon.paint.brush:before { content: "\f1fc"; }
+i.icon.heartbeat:before { content: "\f21e"; }
 
 /* User Actions */
 i.icon.download:before { content: "\f019"; }
@@ -142,6 +143,8 @@ i.icon.share.alternate.square:before { content: "\f1e1"; }
 i.icon.wait:before { content: "\f017"; }
 i.icon.write.square:before { content: "\f14b"; }
 i.icon.share.square:before { content: "\f14d"; }
+i.icon.cart.plus:before { content: "\f217"; }
+i.icon.cart.arrow.down:before { content: "\f218"; }
 
 /* Messages */
 i.icon.help.circle:before { content: "\f059"; }
@@ -160,8 +163,25 @@ i.icon.female:before { content: "\f182"; }
 i.icon.male:before { content: "\f183"; }
 i.icon.child:before { content: "\f1ae"; }
 i.icon.user:before { content: "\f007"; }
+i.icon.user.plus:before { content: "\f234"; }
+i.icon.user.remove:before { content: "\f235"; }
 i.icon.handicap:before { content: "\f193"; }
 i.icon.student:before { content: "\f19d"; }
+i.icon.detective:before { content: "\f21b"; }
+
+/* Gender */
+i.icon.venus:before { content: "\f221"; }
+i.icon.venus.double:before { content: "\f226"; }
+i.icon.venus.mars:before { content: "\f228"; }
+i.icon.mars:before { content: "\f222"; }
+i.icon.mars.double:before { content: "\f227"; }
+i.icon.mars.stroke:before { content: "\f229"; }
+i.icon.mars.stroke.vertical:before { content: "\f22a"; }
+i.icon.mars.stroke.horizontal:before { content: "\f22b"; }
+i.icon.mercury:before { content: "\f223"; }
+i.icon.transgender:before { content: "\f224"; }
+i.icon.transgender.alternate:before { content: "\f225"; }
+i.icon.neuter:before { content: "\f22c"; }
 
 /* View Adjustment */
 i.icon.grid.layout:before { content: "\f00a"; }
@@ -207,6 +227,11 @@ i.icon.moon:before { content: "\f186"; }
 i.icon.fax:before { content: "\f1ac"; }
 i.icon.life.ring:before { content: "\f1cd"; }
 i.icon.bomb:before { content: "\f1e2"; }
+i.icon.soccer.ball:before { content: "\f1e3"; }
+i.icon.binoculars:before { content: "\f1e5"; }
+i.icon.calculator:before { content: "\f1ec"; }
+i.icon.birthday.cake:before {  content: "\f1fd"; }
+i.icon.diamond:before { content: "\f219"; }
 
 /* Shapes */
 i.icon.crosshairs:before { content: "\f05b"; }
@@ -242,13 +267,19 @@ i.icon.minus.square:before { content: "\f146"; }
 i.icon.minus.square.outline:before { content: "\f147"; }
 i.icon.check.square:before { content: "\f14a"; }
 i.icon.plus.square.outline:before { content: "\f196"; }
+i.icon.toggle.off:before { content: "\f204"; }
+i.icon.toggle.on:before { content: "\f205"; }
 
 /* Media */
 i.icon.film:before { content: "\f008"; }
 i.icon.sound:before { content: "\f025"; }
 i.icon.photo:before { content: "\f030"; }
 i.icon.bar.chart:before { content: "\f080"; }
+i.icon.area.chart:before { content: "\f1fe"; }
+i.icon.pie.chart:before { content: "\f200"; }
+i.icon.line.chart:before { content: "\f201"; }
 i.icon.camera.retro:before { content: "\f083"; }
+i.icon.newspaper:before { content: "\f1ea"; }
 
 /* Pointers */
 i.icon.arrow.circle.outline.down:before { content: "\f01a"; }
@@ -298,7 +329,8 @@ i.icon.toggle.left:before { content: "\f191"; }
 
 /* Computer */
 i.icon.power:before { content: "\f011"; }
-i.icon.trash:before { content: "\f014"; }
+i.icon.trash:before { content: "\f1f8"; }
+i.icon.trash.outline:before { content: "\f014"; }
 i.icon.disk.outline:before { content: "\f0a0"; }
 i.icon.desktop:before { content: "\f108"; }
 i.icon.laptop:before { content: "\f109"; }
@@ -306,6 +338,7 @@ i.icon.tablet:before { content: "\f10a"; }
 i.icon.mobile:before { content: "\f10b"; }
 i.icon.game:before { content: "\f11b"; }
 i.icon.keyboard:before { content: "\f11c"; }
+i.icon.plug:before { content: "\f1e6"; }
 
 /* File System */
 i.icon.folder:before { content: "\f07b"; }
@@ -337,6 +370,7 @@ i.icon.css3:before { content: "\f13c"; }
 i.icon.rss.square:before { content: "\f143"; }
 i.icon.openid:before { content: "\f19b"; }
 i.icon.database:before { content: "\f1c0"; }
+i.icon.server:before { content: "\f233"; }
 
 /* Rating */
 i.icon.heart:before { content: "\f004"; }
@@ -373,9 +407,9 @@ i.icon.eject:before { content: "\f052"; }
 i.icon.unmute:before { content: "\f130"; }
 i.icon.mute:before { content: "\f131"; }
 i.icon.video.play:before { content: "\f144"; }
+i.icon.closed.captioning:before { content: "\f20a"; }
 
-
-/* Map & Locations */
+/* Map, Locations, & Transportation */
 i.icon.marker:before { content: "\f041"; }
 i.icon.coffee:before { content: "\f0f4"; }
 i.icon.food:before { content: "\f0f5"; }
@@ -394,6 +428,14 @@ i.icon.spoon:before { content: "\f1b1"; }
 i.icon.car:before { content: "\f1b9"; }
 i.icon.taxi:before { content: "\f1ba"; }
 i.icon.tree:before { content: "\f1bb"; }
+i.icon.bicycle:before { content: "\f206"; }
+i.icon.bus:before { content: "\f207"; }
+i.icon.ship:before { content: "\f21a"; }
+i.icon.motorcycle:before { content: "\f21c"; }
+i.icon.street.view:before { content: "\f21d"; }
+i.icon.hotel:before { content: "\f236"; }
+i.icon.train:before { content: "\f238"; }
+i.icon.subway:before { content: "\f239"; }
 
 /* Tables */
 i.icon.table:before { content: "\f0ce"; }
@@ -447,6 +489,17 @@ i.icon.yen:before { content: "\f157"; }
 i.icon.ruble:before { content: "\f158"; }
 i.icon.won:before { content: "\f159"; }
 i.icon.lira:before { content: "\f195"; }
+i.icon.shekel:before { content: "\f20b"; }
+
+/* Payment Options */
+i.icon.paypal:before { content: "\f1ed"; }
+i.icon.paypal.card:before { content: "\f1f4"; }
+i.icon.google.wallet:before { content: "\f1ee"; }
+i.icon.visa:before { content: "\f1f0"; }
+i.icon.mastercard:before { content: "\f1f1"; }
+i.icon.discover:before { content: "\f1f2"; }
+i.icon.american.express:before { content: "\f1f3"; }
+i.icon.stripe:before { content: "\f1f5"; }
 
 /* Networks and Websites*/
 i.icon.twitter.square:before { content: "\f081"; }
@@ -525,6 +578,26 @@ i.icon.hacker.news:before { content: "\f1d4"; }
 i.icon.tencent.weibo:before { content: "\f1d5"; }
 i.icon.qq:before { content: "\f1d6"; }
 i.icon.wechat:before { content: "\f1d7"; }
+i.icon.slideshare:before { content: "\f1e7"; }
+i.icon.twitch:before { content: "\f1e8"; }
+i.icon.yelp:before { content: "\f1e9"; }
+i.icon.lastfm:before { content: "\f202"; }
+i.icon.lastfm.square:before { content: "\f203"; }
+i.icon.ioxhost:before { content: "\f208"; }
+i.icon.angellist:before { content: "\f209"; }
+i.icon.meanpath:before { content: "\f20c"; }
+i.icon.buysellads:before { content: "\f20d"; }
+i.icon.connectdevelop:before { content: "\f20e"; }
+i.icon.dashcube:before { content: "\f210"; }
+i.icon.forumbee:before { content: "\f211"; }
+i.icon.leanpub:before { content: "\f212"; }
+i.icon.sellsy:before { content: "\f213"; }
+i.icon.shirtsinbulk:before { content: "\f214"; }
+i.icon.simplybuilt:before { content: "\f215"; }
+i.icon.skyatlas:before { content: "\f216"; }
+i.icon.whatsapp:before { content: "\f232"; }
+i.icon.viacoin:before { content: "\f237"; }
+i.icon.medium:before { content: "\f23a"; }
 
 /*******************************
             Aliases
@@ -539,10 +612,14 @@ i.icon.close:before { content: "\f00d"; }
 i.icon.cancel:before { content: "\f00d"; }
 i.icon.delete:before { content: "\f00d"; }
 i.icon.x:before { content: "\f00d"; }
+i.icon.user.times:before { content: "\f235"; }
+i.icon.user.close:before { content: "\f235"; }
+i.icon.user.cancel:before { content: "\f235"; }
+i.icon.user.delete:before { content: "\f235"; }
+i.icon.user.x:before { content: "\f235"; }
 i.icon.zoom.in:before { content: "\f00e"; }
 i.icon.magnify:before { content: "\f00e"; }
 i.icon.shutdown:before { content: "\f011"; }
-i.icon.signal:before { content: "\f012"; }
 i.icon.clock:before { content: "\f017"; }
 i.icon.time:before { content: "\f017"; }
 i.icon.play.circle.outline:before { content: "\f01d"; }
@@ -565,12 +642,14 @@ i.icon.add:before { content: "\f067"; }
 i.icon.eye:before { content: "\f06e"; }
 i.icon.attention:before { content: "\f06a"; }
 i.icon.cart:before { content: "\f07a"; }
-i.icon.plane:before { content: "\f072"; }
 i.icon.shuffle:before { content: "\f074"; }
 i.icon.talk:before { content: "\f075"; }
 i.icon.chat:before { content: "\f075"; }
 i.icon.shopping.cart:before { content: "\f07a"; }
 i.icon.bar.graph:before { content: "\f080"; }
+i.icon.area.graph:before { content: "\f1fe"; }
+i.icon.pie.graph:before { content: "\f200"; }
+i.icon.line.graph:before { content: "\f201"; }
 i.icon.key:before { content: "\f084"; }
 i.icon.privacy:before { content: "\f084"; }
 i.icon.cogs:before { content: "\f085"; }
@@ -589,6 +668,9 @@ i.icon.rss:before { content: "\f09e"; }
 i.icon.hdd.outline:before { content: "\f0a0"; }
 i.icon.bullhorn:before { content: "\f0a1"; }
 i.icon.bell:before { content: "\f0f3"; }
+i.icon.bell.outline:before { content: "\f0a2"; }
+i.icon.bell.slash:before { content: "\f1f6"; }
+i.icon.bell.slash.outline:before { content: "\f1f7"; }
 i.icon.hand.outline.right:before { content: "\f0a4"; }
 i.icon.hand.outline.left:before { content: "\f0a5"; }
 i.icon.hand.outline.up:before { content: "\f0a6"; }
@@ -650,11 +732,17 @@ i.icon.rub:before { content: "\f158"; }
 i.icon.won:before,
 i.icon.krw:before { content: "\f159"; }
 i.icon.btc:before { content: "\f15a"; }
+i.icon.sheqel:before,
+i.icon.ils:before { content: "\f20b"; }
 i.icon.try:before { content: "\f195"; }
 i.icon.zip:before { content: "\f187"; }
 i.icon.dot.circle.outline:before { content: "\f192"; }
-
 i.icon.sliders:before { content: "\f1de"; }
 i.icon.graduation:before { content: "\f19d"; }
 i.icon.\33d:before { content: "\f1b2"; }
 i.icon.weixin:before { content: "\f1d7"; }
+i.icon.gratipay:before { content: "\f184"; }
+i.icon.genderless:before { content: "\f1db"; }
+i.icon.facebook.official { content: "\f230"; }
+i.icon.pinterest.official { content: "\f231"; }
+i.icon.bed:before { content: "\f236"; }


### PR DESCRIPTION
Whew, this took a while. :stuck_out_tongue_closed_eyes: Let me know if you need any changes, or if there's another part of the codebase I need to update in addition to this.

Closes #1642 

Notes:

* The Font Awesome attribution/license banner was shortened here: https://github.com/FortAwesome/Font-Awesome/commit/6fbbefc89fa530c55a33bb5277d8b56ef27b3015
* `signal` and `wifi` are now two separate icons
* Added the `Gender` and `Payment Options` categories
* The `i.icon.plane` was repeated so I removed the second entry
* Font Awesome reference can be found [here](http://fontawesome.io/cheatsheet/) and [here](http://fontawesome.io/icons/)