### PR TITLE
Disabling loading buttons with LESS variable

### DIFF
--- a/src/definitions/elements/button.less
+++ b/src/definitions/elements/button.less
@@ -139,6 +139,21 @@
   color: transparent !important;
   transition: all 0s linear;
 }
+
+.ui.loading.button when (@loadingDisabled = true) {
+    /* Normal */
+    &:hover, &:active{ &:extend(.ui.button); }
+    
+    /* Colors */
+    &.blue:hover, &.blue:active { &:extend(.ui.blue.button); }
+    
+    /* Inverted */
+    &.inverted:hover, &.inverted:active { &:extend(.ui.inverted.button); }
+
+    /* Basic */
+    &.basic:hover, &.basic:active { &:extend(.ui.basic.button); }
+}
+
 .ui.loading.button:before {
   position: absolute;
   content: '';

--- a/src/themes/default/elements/button.variables
+++ b/src/themes/default/elements/button.variables
@@ -56,6 +56,7 @@
 @loaderMargin: @loaderOffset 0em 0em @loaderOffset;
 @invertedLoaderFillColor: rgba(0, 0, 0, 0.15);
 
+
 @transition:
   opacity 0.1s @transitionEasing,
   background-color 0.1s @transitionEasing,
@@ -124,6 +125,7 @@
 
 /* Loading */
 @loadingBackground: @offWhite;
+@loadingDisabled: true;
 
 /*-------------------
         Types


### PR DESCRIPTION
References #1744

LESS has the ability to do pseudo if statements. Given this, we define a boolean for disabling the loading button state

I covered a few cases to determine how it compiles. It will tack on a selector to the normal states when this variable is set to true. It does not create any extra bloat when compiled into the `semantic.css` file

I can proceed to add all other variants (basic inverted colored, etc) if this works for you @jlukic 

Demo: http://patcave.info/semantic-fork/buttons.html

Edit: `pointer-events:none` is not supported for < IE 11, but would work for this as well. See [this](http://caniuse.com/#feat=pointer-events)