### PR TITLE
Cards Improovements: images inside .content and colors for cards

### DIFF
--- a/src/definitions/views/card.less
+++ b/src/definitions/views/card.less
@@ -751,11 +751,11 @@ a.ui.card:hover,
 
 @coloredBorderSize: 2px;
 .ui.black.card:not(.inverted) {
-    box-shadow: 0px @shadowDistance 0px 0px @black;
+  box-shadow: 0px @shadowDistance 0px 0px @black;
   border: 1px solid @solidBorderColor;
 }
 .ui.blue.card:not(.inverted) {
-    box-shadow: 0px @shadowDistance 0px 0px @blue;
+   box-shadow: 0px @shadowDistance 0px 0px @blue;
   border: 1px solid @solidBorderColor;
 }
 .ui.green.card:not(.inverted) {
@@ -763,15 +763,15 @@ a.ui.card:hover,
   border: 1px solid @solidBorderColor;
 }
 .ui.orange.card:not(.inverted) {
-    box-shadow: 0px @shadowDistance 0px 0px @orange;
+  box-shadow: 0px @shadowDistance 0px 0px @orange;
   border: 1px solid @solidBorderColor;
 }
 .ui.pink.card:not(.inverted) {
-    box-shadow: 0px @shadowDistance 0px 0px @pink;
+  box-shadow: 0px @shadowDistance 0px 0px @pink;
   border: 1px solid @solidBorderColor;
 }
 .ui.purple.card:not(.inverted) {
-    box-shadow: 0px @shadowDistance 0px 0px @purple;
+  box-shadow: 0px @shadowDistance 0px 0px @purple;
   border: 1px solid @solidBorderColor;
 }
 .ui.red.card:not(.inverted) {
@@ -797,7 +797,7 @@ a.ui.card:hover,
   color: @white !important;
 }
 .ui.inverted.card,
-.ui.inverted.black card {
+.ui.inverted.black.card {
   box-shadow: 0px @shadowDistance 0px 0px darken(@black, 20%);
 }
 .ui.inverted.blue.card * {

--- a/src/definitions/views/card.less
+++ b/src/definitions/views/card.less
@@ -783,7 +783,8 @@ a.ui.card:hover,
   border: 1px solid @solidBorderColor;
 }
 .ui.yellow.card:not(.inverted) {
-  border-bottom: @coloredBorderSize solid @yellow;
+  box-shadow: 0px @shadowDistance 0px 0px @yellow;
+  border: 1px solid @solidBorderColor;
 }
 
 /*-------------------

--- a/src/definitions/views/card.less
+++ b/src/definitions/views/card.less
@@ -744,3 +744,114 @@ a.ui.card:hover,
 }
 
 .loadUIOverrides();
+
+/*-------------------
+       Colors
+--------------------*/
+
+@coloredBorderSize: 2px;
+.ui.black.card:not(.inverted) {
+    box-shadow: 0px @shadowDistance 0px 0px @black;
+  border: 1px solid @solidBorderColor;
+}
+.ui.blue.card:not(.inverted) {
+    box-shadow: 0px @shadowDistance 0px 0px @blue;
+  border: 1px solid @solidBorderColor;
+}
+.ui.green.card:not(.inverted) {
+    box-shadow: 0px @shadowDistance 0px 0px @green;
+  border: 1px solid @solidBorderColor;
+}
+.ui.orange.card:not(.inverted) {
+    box-shadow: 0px @shadowDistance 0px 0px @orange;
+  border: 1px solid @solidBorderColor;
+}
+.ui.pink.card:not(.inverted) {
+    box-shadow: 0px @shadowDistance 0px 0px @pink;
+  border: 1px solid @solidBorderColor;
+}
+.ui.purple.card:not(.inverted) {
+    box-shadow: 0px @shadowDistance 0px 0px @purple;
+  border: 1px solid @solidBorderColor;
+}
+.ui.red.card:not(.inverted) {
+  box-shadow: 0px @shadowDistance 0px 0px @red;
+  border: 1px solid @solidBorderColor;
+}
+.ui.teal.card:not(.inverted) {
+  box-shadow: 0px @shadowDistance 0px 0px @teal;
+  border: 1px solid @solidBorderColor;
+}
+.ui.yellow.card:not(.inverted) {
+  border-bottom: @coloredBorderSize solid @yellow;
+}
+
+/*-------------------
+   Inverted Colors
+--------------------*/
+
+.ui.inverted.card *,
+.ui.inverted.black.card * {
+  background-color: @black !important;
+  color: @white !important;
+}
+.ui.inverted.card,
+.ui.inverted.black card {
+  box-shadow: 0px @shadowDistance 0px 0px darken(@black, 20%);
+}
+.ui.inverted.blue.card * {
+  background-color: @blue !important;
+  color: @white !important;
+}
+.ui.inverted.blue.card {
+  box-shadow: 0px @shadowDistance 0px 0px darken(@blue, 20%);
+}
+.ui.inverted.green.card * {
+  background-color: @green !important;
+  color: @white !important;
+}
+.ui.inverted.green.card {
+  box-shadow: 0px @shadowDistance 0px 0px darken(@green, 20%);
+}
+.ui.inverted.orange.card * {
+  background-color: @orange !important;
+  color: @white !important;
+}
+.ui.inverted.orange.card {
+  box-shadow: 0px @shadowDistance 0px 0px darken(@orange, 20%);
+}
+.ui.inverted.pink.card * {
+  background-color: @pink !important;
+  color: @white !important;
+}
+.ui.inverted.pink.card {
+  box-shadow: 0px @shadowDistance 0px 0px darken(@pink, 20%);
+}
+.ui.inverted.purple.card * {
+  background-color: @purple !important;
+  color: @white !important;
+}
+.ui.inverted.purple.card {
+  box-shadow: 0px @shadowDistance 0px 0px darken(@purple, 20%);
+}
+.ui.inverted.red.card * {
+  background-color: @red !important;
+  color: @white !important;
+}
+.ui.inverted.red.card {
+  box-shadow: 0px @shadowDistance 0px 0px darken(@red, 20%);
+}
+.ui.inverted.teal.card * {
+  background-color: @teal !important;
+  color: @white !important;
+}
+.ui.inverted.teal.card {
+  box-shadow: 0px @shadowDistance 0px 0px darken(@teal, 20%);
+}
+.ui.inverted.yellow.card * {
+ background-color: @yellow !important;
+  color: @white !important;
+}
+.ui.inverted.yellow.card {
+  box-shadow: 0px @shadowDistance 0px 0px darken(@yellow, 20%);
+}

--- a/src/definitions/views/card.less
+++ b/src/definitions/views/card.less
@@ -115,7 +115,9 @@
   background: @imageBackground;
 }
 .ui.cards > .card > .image > img,
-.ui.card > .image > img {
+.ui.cards > .card > .content > .image > img,
+.ui.card > .image > img,
+.ui.card > .image > .content > img  {
   display: block;
   width: 100%;
   height: auto;

--- a/src/definitions/views/card.less
+++ b/src/definitions/views/card.less
@@ -744,37 +744,3 @@ a.ui.card:hover,
 }
 
 .loadUIOverrides();
-
-/*-------------------
-       Colors
---------------------*/
-
-@coloredBorderSize: 2px;
-.ui.black.card:not(.inverted) {
-  box-shadow: @coloredBorderSize solid @black;
-}
-.ui.blue.card:not(.inverted) {
-  border-bottom: @coloredBorderSize solid @blue;
-}
-.ui.green.card:not(.inverted) {
-  border-bottom: @coloredBorderSize solid @green;
-}
-.ui.orange.card:not(.inverted) {
-  border-bottom: @coloredBorderSize solid @orange;
-}
-.ui.pink.card:not(.inverted) {
-  border-bottom: @coloredBorderSize solid @pink;
-}
-.ui.purple.card:not(.inverted) {
-  border-bottom: @coloredBorderSize solid @purple;
-}
-.ui.red.card:not(.inverted) {
-  border-bottom: @coloredBorderSize solid @red;
-}
-.ui.teal.card:not(.inverted) {
-  border-color: @teal;
-
-}
-.ui.yellow.card:not(.inverted) {
-  border-bottom: @coloredBorderSize solid @yellow;
-}

--- a/src/definitions/views/card.less
+++ b/src/definitions/views/card.less
@@ -115,9 +115,8 @@
   background: @imageBackground;
 }
 .ui.cards > .card > .image > img,
-.ui.cards > .card > .content > .image > img,
 .ui.card > .image > img,
-.ui.card > .image > .content > img  {
+.ui.card > .content  .image   {
   display: block;
   width: 100%;
   height: auto;
@@ -745,3 +744,37 @@ a.ui.card:hover,
 }
 
 .loadUIOverrides();
+
+/*-------------------
+       Colors
+--------------------*/
+
+@coloredBorderSize: 2px;
+.ui.black.card:not(.inverted) {
+  box-shadow: @coloredBorderSize solid @black;
+}
+.ui.blue.card:not(.inverted) {
+  border-bottom: @coloredBorderSize solid @blue;
+}
+.ui.green.card:not(.inverted) {
+  border-bottom: @coloredBorderSize solid @green;
+}
+.ui.orange.card:not(.inverted) {
+  border-bottom: @coloredBorderSize solid @orange;
+}
+.ui.pink.card:not(.inverted) {
+  border-bottom: @coloredBorderSize solid @pink;
+}
+.ui.purple.card:not(.inverted) {
+  border-bottom: @coloredBorderSize solid @purple;
+}
+.ui.red.card:not(.inverted) {
+  border-bottom: @coloredBorderSize solid @red;
+}
+.ui.teal.card:not(.inverted) {
+  border-color: @teal;
+
+}
+.ui.yellow.card:not(.inverted) {
+  border-bottom: @coloredBorderSize solid @yellow;
+}


### PR DESCRIPTION
Today, if you place the post content inside the `.card .content` you will have bad looking `.image`s.

This PR tries to fix this, please look, example from the docs, we just take the .image and put it inside .content:
```html
<div class="ui card">
      <div class="content">
        <a class="header" href="#">Steve Jobes</a>
        <div class="meta">
          <a class="time">Last Seen 2 days ago</a>
        </div>
        <a class="image" href="#">
        <img src="/images/avatar/large/steve.jpg">
      </a>
      </div>
    </div>
```


<caption>Before the PR:</caption>
<img src="http://i.imgur.com/0vxykjL.png" title="before the PR" />



<caption>After the PR:</caption>
<img src="http://i.imgur.com/nH67IAQ.png" title="after the PR" />

