### PR TITLE
Correct IE9 support status

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,11 @@ For more detail into how work with Semantic when building a site please [read ou
 
 * Last 2 Versions FF, Chrome, IE (aka 10+)
 * Safari 6
-* IE 9+ (Browser prefix only)
+* IE 10+
 * Android 4
 * Blackberry 10
 
+Browser prefixes are present for Internet Explorer 9, but the browser is not officially supported.
 
 ## Pull Requests
 


### PR DESCRIPTION
http://cl.ly/image/0Z461V1s371S
http://cl.ly/image/2b0m2T1F3y1X
etc...

I think it is misleading to list IE 9 under browser support.