### PR TITLE
Ability to always use targets offset() for popup.

### DIFF
--- a/src/definitions/modules/popup.js
+++ b/src/definitions/modules/popup.js
@@ -602,14 +602,19 @@ $.fn.popup = function(parameters) {
                 ? parseInt( window.getComputedStyle(targetElement).getPropertyValue(module.is.rtl() ? 'margin-right' : 'margin-left'), 10)
                 : 0,
 
-              target        = (settings.inline || settings.popup)
+              target        = ((settings.inline || settings.popup) && !settings.useTargetOffset)
                 ? $target.position()
-                : $target.offset(),
+                : $.isPlainObject(settings.useTargetOffset) ? settings.useTargetOffset 
+                                                            : $target.offset(),
 
               computedPosition,
               positioning,
               offstagePosition
             ;
+            if ($.isPlainObject(settings.useTargetOffset)) {
+              targetWidth = 0;
+              targetHeight = 0;
+            }
             position    = position    || $module.data(metadata.position)    || settings.position;
             arrowOffset = arrowOffset || $module.data(metadata.offset)      || settings.offset;
 
@@ -1090,6 +1095,7 @@ $.fn.popup.settings = {
   movePopup      : true,
 
   target         : false,
+  useTargetOffset: false,
   popup          : false,
   inline         : false,
   preserve       : false,


### PR DESCRIPTION
When we set popup option to some element and target to another element sometimes we need get targets offset instead position.

For example, I use fullCalnedar event container as a target and some preloaded div as a popup content.
