### PR TITLE
Make select.ui.dropdown visible if js is not available

### DIFF
--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -351,7 +351,6 @@ select.ui.dropdown {
   height: 38px;
   padding: 0em;
   margin: 0em;
-  visibility: hidden;
 }
 .ui.selection.dropdown > .text {
   margin-right: @selectionTextIconDistance;


### PR DESCRIPTION
I just noticed that all my selects with ui.dropdown were invisible when js is not available