### PR TITLE
let beforeSend stop the toggling

### DIFF
--- a/src/definitions/behaviors/state.js
+++ b/src/definitions/behaviors/state.js
@@ -200,8 +200,10 @@ $.fn.state = function(parameters) {
                 apiRequest = $module.api('get request');
                 if(apiRequest) {
                   module.listenTo(apiRequest);
-                  return;
                 }
+                // Don't change the state when the api is defined and the request is undefined
+                // this allows beforeSend to stop the toggling.
+                return;
               }
               module.change.state();
             }


### PR DESCRIPTION
Don't change the state when the api is defined and the request is undefined
                this allows beforeSend to stop the toggling.