### PR TITLE
Correct gulp install script's wrench config for `src/site` merges

### DIFF
--- a/tasks/config/project/install.js
+++ b/tasks/config/project/install.js
@@ -752,7 +752,7 @@ module.exports = {
 
       // copy for site theme
       site: {
-        forceDelete       : true,
+        forceDelete       : false,
         excludeHiddenUnix : true,
         preserveFiles     : true
       }


### PR DESCRIPTION
Even though the gulp install script outputs:
```Site folder exists, merging files (no overwrite) project-dir/semantic/src/site/```

The `src/site` directory is blown away (not preserving existing files) due to the `forceDelete:true` setting.