### PR TITLE
Fix image deformation when using fluid or size classes

### DIFF
--- a/src/definitions/elements/image.less
+++ b/src/definitions/elements/image.less
@@ -159,6 +159,7 @@ img.ui.bordered.image {
 .ui.fluid.image img {
   display: block;
   width: 100%;
+  height: auto;
 }
 
 
@@ -223,6 +224,7 @@ img.ui.bordered.image {
 .ui.mini.images svg,
 .ui.mini.image {
   width: @miniWidth;
+  height: auto;
   font-size: @mini;
 }
 .ui.tiny.images .image,
@@ -230,6 +232,7 @@ img.ui.bordered.image {
 .ui.tiny.images svg,
 .ui.tiny.image {
   width: @tinyWidth;
+  height: auto;
   font-size: @tiny;
 }
 .ui.small.images .image,
@@ -237,6 +240,7 @@ img.ui.bordered.image {
 .ui.small.images svg,
 .ui.small.image {
   width: @smallWidth;
+  height: auto;
   font-size: @small;
 }
 .ui.medium.images .image,
@@ -244,6 +248,7 @@ img.ui.bordered.image {
 .ui.medium.images svg,
 .ui.medium.image {
   width: @mediumWidth;
+  height: auto;
   font-size: @medium;
 }
 .ui.large.images .image,
@@ -251,6 +256,7 @@ img.ui.bordered.image {
 .ui.large.images svg,
 .ui.large.image {
   width: @largeWidth;
+  height: auto;
   font-size: @large;
 }
 .ui.big.images .image,
@@ -258,6 +264,7 @@ img.ui.bordered.image {
 .ui.big.images svg,
 .ui.big.image {
   width: @bigWidth;
+  height: auto;
   font-size: @big;
 }
 .ui.huge.images .image,
@@ -265,6 +272,7 @@ img.ui.bordered.image {
 .ui.huge.images svg,
 .ui.huge.image {
   width: @hugeWidth;
+  height: auto;
   font-size: @huge;
 }
 .ui.massive.images .image,
@@ -272,6 +280,7 @@ img.ui.bordered.image {
 .ui.massive.images svg,
 .ui.massive.image {
   width: @massiveWidth;
+  height: auto;
   font-size: @massive;
 }
 


### PR DESCRIPTION
Currently, images which have height and width attributes set in the HTML don't resize correctly with the size and fluid classes (`ui small image`, `ui fluid image`, etc.). Those attributes are frequently used to avoid the content jumping around in case images take some time to load, which is why I figured this simple fix might be useful.

What happens in the actual version: the images get squeezed horizontally but not vertically, not preserving their aspect ratio.

What happens after my changes: the image gets resized both horizontally and vertically, keeping their aspect ratio intact.