### PR TITLE
[Popup] Doesn't remove Window Events on Destroy

### DIFF
--- a/src/definitions/modules/popup.js
+++ b/src/definitions/modules/popup.js
@@ -152,6 +152,9 @@ $.fn.popup = function(parameters) {
             .off(eventNamespace)
             .removeData(moduleNamespace)
           ;
+          $window
+              .off('resize' + eventNamespace, module.event.resize)
+          ;
         },
 
         event: {


### PR DESCRIPTION
In an Angular JS application of mine I was suffering from a terrible memory leak. The extensive use of Semantic UI popups made me think they are the culprit. So I investigated a bit and found the cause. The **initialize** method of the Popup module attaches a listener on the **window.resize** event.but does not unbind it when its **destroy** behaviour is invoked. The proposed changes solve the memory leak.