### PR TITLE
Adding missing event namespace in form validation

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -100,7 +100,7 @@ $.fn.form = function(fields, parameters) {
         attachEvents: function(selector, action) {
           action = action || 'submit';
           $(selector)
-            .on('click', function(event) {
+            .on('click' + eventNamespace, function(event) {
               module[action]();
               event.preventDefault();
             })


### PR DESCRIPTION
The namespace for e.g. the submit handler has been missed, which causes 'destroy' not to tear them down. 

I'm on Meteor which reuses DOM elements all the time, so I have to destroy / reinitialise my dynamic form all the time. This bug caused submit handlers to stack up.