### PR TITLE
Actually use @secondaryPointingActiveBorderColor variable in menu.

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -874,7 +874,7 @@
 .ui.secondary.pointing.menu > .menu > .item.active,
 .ui.secondary.pointing.menu > .item.active {
   background-color: transparent;
-  border-color: rgba(0, 0, 0, 0.4);
+  border-color: @secondaryPointingActiveBorderColor;
   box-shadow: none;
   color: @secondaryPointingActiveTextColor;
 }


### PR DESCRIPTION
Hi,

I've noticed (while customizing theme) that the aforementioned variable is not used and an active border in the secondary pointing menu is hard-coded.