### PR TITLE
Scrape yaml metadata from docs repo and generate metadata.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Environment | Install Script | Repo
 --- | --- | --- | 
 CSS Only | `npm install semantic-ui-css` | [CSS Repo](https://github.com/Semantic-Org/Semantic-UI-CSS)
 [LESS](https://github.com/less/less.js/) Only | `npm install semantic-ui-less` | [LESS Repo](https://github.com/Semantic-Org/Semantic-UI-LESS)
+[LESS](https://github.com/less/less.js/) plugin | `npm install less-plugin-semantic-ui` | [LESS Plugin Repo](https://github.com/bassjobsen/less-plugin-semantic-ui/)
 [EmberJS](http://emberjs.com/) | `ember install:addon semantic-ui-ember` | [Ember Repo](https://github.com/Semantic-Org/Semantic-UI-Ember)
 |[Meteor](https://www.meteor.com/) - [LESS](https://github.com/less/less.js/) | `meteor add semantic:ui` | [LESS Repo](https://github.com/Semantic-Org/Semantic-UI-LESS) |
 |[Meteor](https://www.meteor.com/) - CSS | `meteor add semantic:ui-css` | [CSS Repo](https://github.com/Semantic-Org/Semantic-UI-CSS) |

--- a/package.json
+++ b/package.json
@@ -75,6 +75,8 @@
     "jquery": "^2.1.3",
     "mkdirp": "^0.5.0",
     "require-dot-file": "^0.4.0",
+    "map-stream": "^0.1.0",
+    "yamljs": "^0.2.1",
     "wrench": "git://github.com/derekslife/wrench-js.git#156eaceed68ed31ffe2a3ecfbcb2be6ed1417fb2"
   },
   "devDependencies": {

--- a/tasks/config/docs.js
+++ b/tasks/config/docs.js
@@ -19,6 +19,9 @@ module.exports = {
       compressed   : '../docs/out/dist/components/',
       themes       : '../docs/out/dist/themes/'
     },
+    template: {
+      eco: '../docs/server/documents/'
+    },
     clean: '../docs/out/dist/'
   }
 };

--- a/tasks/docs/build.js
+++ b/tasks/docs/build.js
@@ -8,6 +8,7 @@ var
   // node dependencies
   console      = require('better-console'),
   fs           = require('fs'),
+  map          = require('map-stream'),
 
   // gulp dependencies
   autoprefixer = require('gulp-autoprefixer'),
@@ -31,6 +32,9 @@ var
   configSetup  = require('../config/project/config'),
   tasks        = require('../config/project/tasks'),
   install      = require('../config/project/install'),
+
+  // metadata parsing
+  metadata     = require('./metadata'),
 
   // shorthand
   globs,
@@ -65,6 +69,21 @@ module.exports = function(callback) {
   source = config.paths.source;
 
   /*--------------
+   Parse metadata
+   ---------------*/
+
+  // parse all *.html.eco in docs repo, data will end up in
+  // metadata.result object.  Note this assumes that the docs
+  // repository is present and in proper directory location as
+  // specified by docs.json.
+  gulp.src(config.paths.template.eco + '**/*.html.eco')
+    .pipe(map(metadata.parser))
+    .on('end', function() {
+      fs.writeFile(output.less + '/metadata.json', JSON.stringify(metadata.result, null, 2));
+    });
+  ;
+
+  /*--------------
      Copy Source
   ---------------*/
 
@@ -73,7 +92,6 @@ module.exports = function(callback) {
     .pipe(gulp.dest(output.less))
     .pipe(print(log.created))
   ;
-
 
   /*--------------
         Build

--- a/tasks/docs/metadata.js
+++ b/tasks/docs/metadata.js
@@ -1,0 +1,107 @@
+/*******************************
+           Summarize Docs
+*******************************/
+
+var
+  // node dependencies
+  console      = require('better-console'),
+  fs           = require('fs'),
+  YAML         = require('yamljs')
+;
+
+var data = {};
+
+/**
+ * Test for prefix in string.
+ * @param {string} str
+ * @param {string} prefix
+ * @return {boolean}
+ */
+function startsWith(str, prefix) {
+  return str.indexOf(prefix) === 0;
+};
+
+/**
+ * Parses a file for metadata and stores result in data object.
+ * @param {File} file - object provided by map-stream.
+ * @param {function(?,File)} - callback provided by map-stream to
+ * reply when done.
+ */
+function parseFile(file, cb) {
+
+  if (file.isNull())
+    return cb(null, file); // pass along
+  if (file.isStream())
+    return cb(new Error("Streaming not supported"));
+
+  try {
+
+    var
+    /** @type {string} */
+    text = String(file.contents.toString('utf8')),
+    lines = text.split('\n');
+
+    if (!lines)
+      return;
+
+    var filename = file.path;
+    filename = filename.substring(0, filename.length - 4);
+    var key = 'server/documents';
+    var position = filename.indexOf(key);
+    if (position < 0)
+      return cb(null, file);
+    filename = filename.substring(position + key.length + 1, filename.length);
+
+    //console.log('Parsing ' + filename);
+
+    var n = lines.length,
+        active = false,
+        yaml = [],
+        line
+    ;
+
+    var line;
+    for (var i = 0; i < n; i++) {
+      line = lines[i];
+
+      // Wait for metadata block to begin
+      if (!active) {
+        if (startsWith(line, '---'))
+          active = true;
+        continue;
+      }
+
+
+      // End of metadata block, stop parsing.
+      if (startsWith(line, '---'))
+        break;
+
+      yaml.push(line);
+    }
+
+    // Parse yaml.
+    var meta = YAML.parse(yaml.join('\n'));
+    meta.category = meta.type;
+    meta.filename = filename;
+    meta._title = meta.title; // preserve original, just in case
+    meta.title = meta.type + ': ' + meta.title;
+    // Primary key will by filepath
+    data[filename] = meta;
+
+    //console.log("Parsed " + filename + ": " + JSON.stringify(meta));
+
+  } catch(e) {
+    console.log(e);
+  }
+
+  cb(null,file);
+
+}
+
+/**
+ * Export function expected by map-stream.
+ */
+module.exports = {
+  result: data,
+  parser: parseFile
+};


### PR DESCRIPTION
1. Adds a new task `metadata.js` that parses a docpad *.html.eco template and extracts the metadata from the beginning of the file.
2. Accumulates metadata into a `JsonArray`, each element containing a `JsonObject` that describes the file from 1.
3. Emits a new file into sister directory, typically `../docs/out/src/metadata.json`.

Rebased onto next that pulled in change from another user.  Sorry.