### PR TITLE
Add onOpening callback to Accordion

### DIFF
--- a/src/definitions/modules/accordion.js
+++ b/src/definitions/modules/accordion.js
@@ -157,6 +157,7 @@ $.fn.accordion = function(parameters) {
           ;
           if(isUnopen) {
             module.debug('Opening accordion content', $activeTitle);
+            settings.onOpening.call(this);
             if(settings.exclusive) {
               module.closeOthers.call($activeTitle);
             }
@@ -545,6 +546,7 @@ $.fn.accordion.settings = {
   duration        : 350,
   easing          : 'easeOutQuad',
 
+  onOpening       : function(){},
   onOpen          : function(){},
   onClose         : function(){},
   onChange        : function(){},


### PR DESCRIPTION
I added a new callback to the Accordion module, named `onOpening`, which will be triggered before the Accordion menu is about to be opened.