### PR TITLE
Exclude list item link that are buttons from link color override.

### DIFF
--- a/src/definitions/elements/list.less
+++ b/src/definitions/elements/list.less
@@ -383,39 +383,39 @@ ol.ui.list ol,
 
 .ui.link.list .item,
 .ui.link.list a.item,
-.ui.link.list .item a {
+.ui.link.list .item a:not(.ui.button) {
   color: @linkListItemColor;
   transition: @linkListTransition;
 }
 .ui.link.list a.item:hover,
-.ui.link.list .item a:hover {
+.ui.link.list .item a:not(.ui.button):hover {
   color: @linkListItemHoverColor;
 }
 .ui.link.list a.item:active,
-.ui.link.list .item a:active {
+.ui.link.list .item a:not(.ui.button):active {
   color: @linkListItemDownColor;
 }
 .ui.link.list .active.item,
-.ui.link.list .active.item a {
+.ui.link.list .active.item a:not(.ui.button) {
   color: @linkListItemActiveColor;
 }
 
 /* Inverted */
 .ui.inverted.link.list .item,
 .ui.inverted.link.list a.item,
-.ui.inverted.link.list .item a {
+.ui.inverted.link.list .item a:not(.ui.button) {
   color: @invertedLinkListItemColor;
 }
 .ui.inverted.link.list a.item:hover,
-.ui.inverted.link.list .item a:hover {
+.ui.inverted.link.list .item a:not(.ui.button):hover {
   color: @invertedLinkListItemHoverColor;
 }
 .ui.inverted.link.list a.item:active,
-.ui.inverted.link.list .item a:active {
+.ui.inverted.link.list .item a:not(.ui.button):active {
   color: @invertedLinkListItemDownColor;
 }
 .ui.inverted.link.list a.active.item,
-.ui.inverted.link.list .active.item a {
+.ui.inverted.link.list .active.item a:not(.ui.button) {
   color: @invertedLinkListItemActiveColor;
 }
 


### PR DESCRIPTION
This is purely my point of view, but list items that are link-type buttons text color should not be overrided. I've ran multiple times to this problem when I try to create a list of buttons and all the time the text on the link is in the wrong color.