### PR TITLE
Corrected order of operations to enable precision (rounding).

### DIFF
--- a/src/definitions/modules/progress.js
+++ b/src/definitions/modules/progress.js
@@ -236,7 +236,7 @@ $.fn.progress = function(parameters) {
             if(settings.precision === 0) {
               return Math.round(displayPercent);
             }
-            return Math.round(displayPercent * (10 * settings.precision) / (10 * settings.precision) );
+            return Math.round(displayPercent * (10 * settings.precision)) / (10 * settings.precision);
           },
 
           percent: function() {
@@ -361,11 +361,11 @@ $.fn.progress = function(parameters) {
               percent = Math.round(percent);
             }
             else {
-              percent = Math.round(percent * (10 * settings.precision) / (10 * settings.precision) );
+              percent = Math.round(percent * (10 * settings.precision)) / (10 * settings.precision);
             }
             module.percent = percent;
             if(module.total) {
-              module.value = Math.round( (percent / 100) * module.total);
+              module.value = Math.round( (percent / 100) * module.total * (10 * settings.precision)) / (10 * settings.precision);
             }
             else if(settings.limitValues) {
               module.value = (module.value > 100)


### PR DESCRIPTION
I was attempting to put decimals in the progress bar (e.g. 9.4 of 10) and found that the precision rounding order of operations was out of order causing everything to round to 0 decimals. 

I corrected that order, however, many people may have gotten used to this behavior so the only additional change I considered was defaulting the precision to 0. 

I hope this helps!

