### PR TITLE
Make ordered list numbers in an inverted context be visible

### DIFF
--- a/src/definitions/elements/list.less
+++ b/src/definitions/elements/list.less
@@ -594,9 +594,9 @@ ol.ui.list li:before,
   opacity: @orderedCountOpacity;
 }
 
-ol.ui.list li:before,
-.ui.ordered.list .list > .item:before,
-.ui.ordered.list > .item:before {
+ol.ui.inverted.list li:before,
+.ui.ordered.inverted.list .list > .item:before,
+.ui.ordered.inverted.list > .item:before {
   color: @orderedInvertedCountColor;
 }
 

--- a/src/definitions/elements/list.less
+++ b/src/definitions/elements/list.less
@@ -559,7 +559,6 @@ ul.ui.horizontal.bulleted.list li:first-child::before,
   display: none;
 }
 
-
 /*-------------------
        Ordered
 --------------------*/
@@ -595,6 +594,11 @@ ol.ui.list li:before,
   opacity: @orderedCountOpacity;
 }
 
+ol.ui.list li:before,
+.ui.ordered.list .list > .item:before,
+.ui.ordered.list > .item:before {
+  color: @orderedInvertedCountColor;
+}
 
 /* Child Lists */
 ol.ui.list ol,
@@ -885,3 +889,4 @@ ol.ui.horizontal.list li:before,
 }
 
 .loadUIOverrides();
+

--- a/src/themes/default/elements/list.variables
+++ b/src/themes/default/elements/list.variables
@@ -166,6 +166,8 @@
 @orderedChildCountDistance: 1em;
 @orderedChildCountOffset: -2em;
 
+@orderedInvertedCountColor: @invertedLightTextColor;
+
 /* Horizontal Ordereded */
 @horizontalOrderedCountDistance: 0.5em;
 


### PR DESCRIPTION
See http://jsfiddle.net/ka98j2pv/2/
This commit introduces @orderedInvertedCountColor for this purpose.
@jlukic If prefer to make changes on your branch and close this PR, no biggie.