### PR TITLE
bower.json: main: semantic.css => semantic.less

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "jquery"      : ">=1.8"
   },
   "main": [
-    "dist/semantic.css",
+    "src/semantic.less",
     "dist/semantic.js"
   ],
   "keywords": [


### PR DESCRIPTION
Per bower/bower.json-spec#43 :
> Use source files with module exports and imports over pre-built distribution files.

Also, the example in that PR includes `/sass/motion.scss` in and excludes `/dist/movement.css` & `/dist/movement.min.css` from its `main`.