### PR TITLE
#2280 Fix Typos with Olive color

### DIFF
--- a/src/definitions/elements/icon.less
+++ b/src/definitions/elements/icon.less
@@ -249,7 +249,7 @@ i.olive.icon {
   color: @olive !important;
 }
 i.inverted.olive.icon {
-  color: @lightGreen !important;
+  color: @lightOlive !important;
 }
 i.inverted.bordered.olive.icon,
 i.inverted.circular.olive.icon {

--- a/src/definitions/modules/progress.less
+++ b/src/definitions/modules/progress.less
@@ -387,7 +387,7 @@
   background-color: @olive;
 }
 .ui.olive.inverted.progress .bar {
-  background-color: @lightGreen;
+  background-color: @lightOlive;
 }
 
 /* Green */


### PR DESCRIPTION
#2280 Two small typos in `definitions/elements/icon.less` and `definitions/modules/progress.less`