### PR TITLE
Fixes icon rendering problem in OSX + webkit

### DIFF
--- a/src/definitions/elements/icon.less
+++ b/src/definitions/elements/icon.less
@@ -53,6 +53,7 @@ i.icon {
   speak: none;
   font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
   backface-visibility: hidden;
 }
 


### PR DESCRIPTION
The issue is pretty much the same as #662, but now in webkit. Using -webkit-font-smoothing: antialiased solves the problem.

I made a jsfiddle that demonstrate it: http://jsfiddle.net/davialexandre/trx0bpz8/. Here is an image of how the icons are rendered (I am using a dark background to make it easier to notice the difference). The first row is using -webkit-font-smoothing and the second one is how the icons are currently rendered:

![captura de tela 2015-06-02 as 14 47 41](https://cloud.githubusercontent.com/assets/388373/7943096/c6ad018a-0938-11e5-978b-1409f95a8d50.png)


