### PR TITLE
Also copy component specific assets from themes. #2358

### DIFF
--- a/tasks/build/assets.js
+++ b/tasks/build/assets.js
@@ -27,7 +27,10 @@ module.exports = function(callback) {
   console.info('Building assets');
 
   // copy assets
-  return gulp.src(source.themes + '/**/assets/**/' + globs.components + '?(s).*')
+  return gulp.src([
+    source.themes + '/**/assets/**/' + globs.components + '?(s).*',
+    source.themes + '/**/assets/' + globs.components + '?(s)/**/*'
+  ])
     .pipe(gulpif(config.hasPermission, chmod(config.permission)))
     .pipe(gulp.dest(output.themes))
   ;


### PR DESCRIPTION
This still works like it did before only that it also checks for `myTheme/assets/{component}/`. If it finds component specific assets it copies those as well.