### PR TITLE
Allow link underline and hover link underline to differ

### DIFF
--- a/src/definitions/globals/site.less
+++ b/src/definitions/globals/site.less
@@ -122,6 +122,7 @@ a {
 }
 a:hover {
   color: @linkHoverColor;
+  text-decoration: @linkHoverUnderline;
 }
 
 /*******************************

--- a/src/themes/default/globals/site.variables
+++ b/src/themes/default/globals/site.variables
@@ -103,6 +103,7 @@
 @linkColor           : #4183C4;
 @linkUnderline       : none;
 @linkHoverColor      : darken(saturate(@linkColor, 10), 5);
+@linkHoverUnderline  : @linkUnderline;
 
 /*-------------------
   Highlighted Text

--- a/src/themes/flat/globals/site.variables
+++ b/src/themes/flat/globals/site.variables
@@ -63,6 +63,7 @@
 @linkColor           : #009FDA;
 @linkUnderline       : none;
 @linkHoverColor      : lighten( @linkColor, 5);
+@linkHoverUnderline  : @linkUnderline;
 
 @highlightBackground : #FFFFCC;
 @highlightColor      : @textColor;

--- a/src/themes/material/globals/site.variables
+++ b/src/themes/material/globals/site.variables
@@ -102,6 +102,7 @@
 @linkColor           : #009FDA;
 @linkUnderline       : none;
 @linkHoverColor      : lighten(@linkColor, 5);
+@linkHoverUnderline  : @linkUnderline;
 
 /*-------------------
   Highlighted Text


### PR DESCRIPTION
I'm working on a site where I need links to be underlined when hovered, but otherwise not.

This patch allows you to add @linkHoverUnderline to your site.variables to make this possible.