### PR TITLE
Fixes "SyntaxError: unreachable code after return statement"

### DIFF
--- a/src/definitions/modules/transition.js
+++ b/src/definitions/modules/transition.js
@@ -614,7 +614,7 @@ $.fn.transition = function() {
           },
           userStyle: function(style) {
             style = style || $module.attr('style') || '';
-            return style.replace(/display.*?;/, '');;
+            return style.replace(/display.*?;/, '');
           },
           transitionExists: function(animation) {
             return $.fn.transition.exists[animation];


### PR DESCRIPTION
This error was being triggered in Firefox.