### PR TITLE
remove popup position check

### DIFF
--- a/src/definitions/modules/popup.js
+++ b/src/definitions/modules/popup.js
@@ -687,11 +687,6 @@ $.fn.popup = function(parameters) {
             popup  = calculations.popup;
             parent = calculations.parent;
 
-            if(target.top === 0 && target.left === 0) {
-              module.debug('Popup target is hidden, no action taken');
-              return false;
-            }
-
             if(settings.inline) {
               module.debug('Adding margin to calculation', target.margin);
               if(position == 'left center' || position == 'right center') {


### PR DESCRIPTION
As suggested in `popup parent position ~absolute/fixed will not display` #2518
removing the popup position check..