### PR TITLE
Properly set the dropdown value when dealing with remote loaded choices

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -2090,6 +2090,12 @@ $.fn.dropdown = function(parameters) {
                   return;
                 }
               }
+
+              if($input.is('select') && settings.apiSettings) {
+                module.debug('Adding an option to the select before setting the value', value);
+                module.add.optionValue(value);
+              }
+
               module.debug('Updating input value', value, currentValue);
               $input
                 .val(value)


### PR DESCRIPTION
This problem happens only when we have a dropdown created from a select
that loads remote content. In this scenario, we don't know in advance
which choices will be available, so we start with a select without any
options. When an choice is selected, module.set.value will try to set
the select value, but it will fail, since there's no options.

To fix this, module.set.value will add a new option to the select, before
setting the value. This will be done only if the dropdown input is a select
and if we are dealing with remote loaded content.