### PR TITLE
Fixes #2572

### DIFF
--- a/src/definitions/modules/checkbox.js
+++ b/src/definitions/modules/checkbox.js
@@ -177,6 +177,7 @@ $.fn.checkbox = function(parameters) {
               return;
             }
             module.toggle();
+            event.preventDefault();
           },
           keydown: function(event) {
             var


### PR DESCRIPTION
Since the input state is toggled by set.checked() the default behaviour of this click does not need to happen. 

This fixes the multiple trigger bug with labels and input event bubbling, while permitting input state change and bindings to still work.