### PR TITLE
Update form.less

### DIFF
--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -465,8 +465,8 @@
 .ui.form .field.error .ui.dropdown,
 .ui.form .field.error .ui.dropdown .text,
 .ui.form .field.error .ui.dropdown .item {
-  background: @formErrorBackground;
-  color: @formErrorColor;
+  background: @formErrorBackground !important;
+  color: @formErrorColor !important;
 }
 .ui.form .fields.error .field .ui.dropdown,
 .ui.form .field.error .ui.dropdown {
@@ -478,12 +478,12 @@
 }
 .ui.form .fields.error .field .ui.dropdown:hover .menu,
 .ui.form .field.error .ui.dropdown:hover .menu {
-  border-color: @formErrorBorder;
+  border-color: @formErrorBorder !important;
 }
 .ui.form .fields.error .field .ui.multiple.selection.dropdown > .label,
 .ui.form .field.error .ui.multiple.selection.dropdown > .label {
-  background-color: @dropdownErrorLabelBackground;
-  color: @dropdownErrorLabelColor;
+  background-color: @dropdownErrorLabelBackground !important;
+  color: @dropdownErrorLabelColor !important;
 }
 
 /* Hover */


### PR DESCRIPTION
form error dropdown should have highest priority, otherwise some of my styles override error styles. like this:
![image](https://cloud.githubusercontent.com/assets/10534563/8634859/3c90b580-281b-11e5-97d5-d7329a975a83.png)
should be:
![image](https://cloud.githubusercontent.com/assets/10534563/8634863/5f49ec90-281b-11e5-9fa8-e770999f3988.png)
