### PR TITLE
Fixed typo in README.md

### DIFF
--- a/tasks/README.md
+++ b/tasks/README.md
@@ -10,8 +10,6 @@
 These tasks can be imported into your own gulpfile allowing you to avoid using Semantic's build tools
 
 ```javascript
-var
-  watch = require('path/to/semantic/tasks/watch')
-;
-gulp.task('watch ui', 'Watch Semantic UI', watch));
+var watch = require('path/to/semantic/tasks/watch');
+gulp.task('watch ui', 'Watch Semantic UI', watch);
 ```


### PR DESCRIPTION
There appeared to be a spacing error for line 13 and an extra paren on line 14.