### PR TITLE
[Search] Allow custom display fields

### DIFF
--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -824,7 +824,7 @@ $.fn.search = function(parameters) {
               }
             }
             if($.isFunction(template)) {
-              html = template(response);
+              html = template(response, settings);
             }
             else {
               module.error(error.noTemplate, false);
@@ -1048,6 +1048,9 @@ $.fn.search.settings = {
     'description'
   ],
   // fields to search
+  
+  displayField   : '',
+  // field to display in standard results template
 
   searchFullText : true,
   // whether to include fuzzy results in local search
@@ -1225,7 +1228,7 @@ $.fn.search.settings = {
       }
       return false;
     },
-    standard: function(response) {
+    standard: function(response, settings) {
       var
         html = ''
       ;
@@ -1247,6 +1250,9 @@ $.fn.search.settings = {
             ;
           }
           html += '<div class="content">';
+          if (settings.displayField.length > 0){
+              html += '<div class="title">' + result[settings.displayField] + '</div>';
+          }
           if(result.price !== undefined) {
             html += '<div class="price">' + result.price + '</div>';
           }


### PR DESCRIPTION
This change allow the developter to choose the field to display in the results. So we don't have to change our json's object field names to the fixed ones (title, price and description).
usage:

$('div[name="searchDiv"]').search({
            source: [{id:0, myfield: 'some text', extrafield: 'ST'}, {id:1, myfield: 'another text', extrafield: 'AT'}],
            searchFields: [
                myfield
            ],
            displayField: extrafield
        });