### PR TITLE
Sticky position fix for fluid menus

### DIFF
--- a/src/definitions/modules/sticky.js
+++ b/src/definitions/modules/sticky.js
@@ -390,12 +390,8 @@ $.fn.sticky = function(parameters) {
           },
           size: function() {
             if(module.cache.element.height !== 0 && module.cache.element.width !== 0) {
-              $module
-                .css({
-                  width  : module.cache.element.width,
-                  height : module.cache.element.height
-                })
-              ;
+              $module.get(0).style.setProperty('width',  module.cache.element.width  + 'px', 'important');
+              $module.get(0).style.setProperty('height', module.cache.element.height + 'px', 'important');
             }
           }
         },


### PR DESCRIPTION
For fluid menus (constrained in width by a grid of some description), the sticky needs to update the dimensions with !important, since it needs to override:

.ui.menu.fluid,.ui.vertical.menu.fluid{
  width:100%!important
}

Otherwise, the sticky menu will simply flow all over the screen..