### PR TITLE
[Dropdown] Allow `onHide` callbacks to prevent Hiding

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -423,9 +423,7 @@ $.fn.dropdown = function(parameters) {
           ;
           if( module.is.active() ) {
             module.debug('Hiding dropdown');
-            var hideDropdown = settings.onHide.call(element);
-
-            if (hideDropdown === false) {
+            if(settings.onHide.call(element) === false) {
               module.animate.hide(function() {
                 module.remove.visible();
                 callback.call(element);

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -423,11 +423,14 @@ $.fn.dropdown = function(parameters) {
           ;
           if( module.is.active() ) {
             module.debug('Hiding dropdown');
-            module.animate.hide(function() {
-              module.remove.visible();
-              callback.call(element);
-            });
-            settings.onHide.call(element);
+            var hideDropdown = settings.onHide.call(element);
+
+            if (hideDropdown === false) {
+              module.animate.hide(function() {
+                module.remove.visible();
+                callback.call(element);
+              });
+            }
           }
         },
 


### PR DESCRIPTION
I found out that there is no way to prevent dropdown from being hidden in specific cases, so I thought this might be quite handy.
In my scenario, I use an input field with attached `jquery-datepicker` and whenever I want to jump between month in it, the dropdown hides.

Therefore I propose to add this small feature.