### PR TITLE
[Popup] Look for inline popup in all siblings of target, not just immediate sibling

### DIFF
--- a/src/definitions/modules/popup.js
+++ b/src/definitions/modules/popup.js
@@ -96,7 +96,7 @@ $.fn.popup = function(parameters) {
           }
           else {
             if(settings.inline) {
-              $popup = $target.next(selector.popup).eq(0);
+              $popup = $target.nextAll(selector.popup).eq(0);
               settings.popup = $popup;
             }
           }


### PR DESCRIPTION
Specifying inline:true to popups should find .ui.popup in all siblings, not just the immediately following one (sometimes it isn't possible to guarantee that the popup is written immediately next, esp. with ajax content and complex sites). 