### PR TITLE
[Dropdown] Ignore Input change event on load if specified in settings

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -2112,10 +2112,10 @@ $.fn.dropdown = function(parameters) {
                 module.add.optionValue(value);
               }
               module.debug('Updating input value', value, currentValue);
-              $input
-                .val(value)
-                .trigger('change')
-              ;
+              $input.val(value);
+              if(!module.is.initialLoad()) {
+                $input.trigger('change');
+              }
             }
             else {
               module.verbose('Storing value in metadata', value, $input);


### PR DESCRIPTION
I am trying to listen to the "change" events on all selects & inputs in order to trigger an autosave. However, all .dropdowns will trigger a "change" even as part of the init (see link above). I do not see how that is helpful, so I propose skipping this on initial load.