### PR TITLE
Set API.settings.debug to false as documented

### DIFF
--- a/dist/components/api.js
+++ b/dist/components/api.js
@@ -990,7 +990,7 @@ $.api.settings = {
   name              : 'API',
   namespace         : 'api',
 
-  debug             : true,
+  debug             : false,
   verbose           : false,
   performance       : true,
 


### PR DESCRIPTION
I just read your [documentation](http://semantic-ui.com/behaviors/api.html#/settings) and you say that the debug option is false by default but it doesn't, it was true. I just changed this to false so it fits with your documentation.


Regards!