### PR TITLE
Single step border radius fix

### DIFF
--- a/src/definitions/elements/step.less
+++ b/src/definitions/elements/step.less
@@ -102,11 +102,6 @@
   border-radius: @stepsBorderRadius 0em 0em @stepsBorderRadius;
 }
 
-/* Only Step */
-.ui.steps .step:only-child {
-  border-radius: @stepsBorderRadius;
-}
-
 /* Last Step */
 .ui.steps .step:last-child {
   border-radius: 0em @stepsBorderRadius @stepsBorderRadius 0em;
@@ -247,6 +242,18 @@
 }
 .ui.vertical.steps .active.step:last-child:after {
   display: @verticalActiveLastArrowDisplay;
+}
+
+
+/*---------------
+     Unbiased
+----------------*/
+
+/* Only Step */
+.ui.steps, .ui.vertical.steps {
+  .step:only-child {
+    border-radius: @stepsBorderRadius;
+  }
 }
 
 


### PR DESCRIPTION
There's an issue with the single step element where the border radius style is adhering to a "last child" case. You can see the bug here: http://jsfiddle.net/o7wn9xjd/. I am able to replicate in IE10, IE11, Chrome, Safari and Firefox (I did not test the mobile browsers).

The solution addresses the concept of "the latter rule wins". In this case, the rule for `:last-child` holds true during any `:only-child` case. This was overriding the `:only-child` style.