### PR TITLE
Add support for transition none to the popup module.

### DIFF
--- a/src/definitions/modules/popup.js
+++ b/src/definitions/modules/popup.js
@@ -375,7 +375,15 @@ $.fn.popup = function(parameters) {
         animate: {
           show: function(callback) {
             callback = $.isFunction(callback) ? callback : function(){};
-            if(settings.transition && $.fn.transition !== undefined && $module.transition('is supported')) {
+            if(settings.transition == 'none') {
+              module.set.visible();
+              $popup.transition('show');
+              callback.call(element);
+              settings.onVisible.call($popup, element);
+              // Bind close on next event loop iteration to prevent direct close due to the click event opening this popup.
+              setTimeout(function() { module.bind.close(); }, 0);
+            }
+            else if(settings.transition && $.fn.transition !== undefined && $module.transition('is supported')) {
               module.set.visible();
               $popup
                 .transition({
@@ -403,7 +411,13 @@ $.fn.popup = function(parameters) {
               module.debug('onHide callback returned false, cancelling popup animation');
               return;
             }
-            if(settings.transition && $.fn.transition !== undefined && $module.transition('is supported')) {
+            if(settings.transition == 'none') {
+              $popup.transition('hide');
+              module.reset();
+              callback.call(element);
+              settings.onHidden.call($popup, element);
+            }
+            else if(settings.transition && $.fn.transition !== undefined && $module.transition('is supported')) {
               $popup
                 .transition({
                   animation  : settings.transition + ' out',


### PR DESCRIPTION
I'm working on support for IE9 for a site, and for this I need support for transition none in the popup module. This was already available in the dropdown, which is implemented about the same way.

I was required to put the call to module.bind.close(); in a timeout callback to bind it in the next event loop iteration. This is because otherwise the popup would close immediately due to the click event still being bubbled.

I have another suggestion: it would probably be a good idea to default to no transition when transition is not supported. This way you will still support the maximum browsers, and won't compromise the code with hacks or anything.
