### PR TITLE
Add support for js-cookie

### DIFF
--- a/src/definitions/modules/nag.js
+++ b/src/definitions/modules/nag.js
@@ -198,6 +198,10 @@ $.fn.nag = function(parameters) {
               $.cookie(key, value, options);
               module.debug('Value stored using cookie', key, value, options);
             }
+            else if(Cookies !== undefined) {
+              Cookies.set(key, value, options);
+              module.debug('Value stored using cookie', key, value, options);
+            }
             else {
               module.error(error.noCookieStorage);
               return;
@@ -213,6 +217,10 @@ $.fn.nag = function(parameters) {
             // get by cookie
             else if($.cookie !== undefined) {
               storedValue = $.cookie(key);
+            }
+            // get by cookie
+            else if(Cookies !== undefined) {
+              storedValue = Cookies.get(key);
             }
             else {
               module.error(error.noCookieStorage);
@@ -232,6 +240,10 @@ $.fn.nag = function(parameters) {
             // store by cookie
             else if($.cookie !== undefined) {
               $.removeCookie(key, options);
+            }
+            // store by cookie
+            else if(Cookie !== undefined) {
+              Cookies.remove(key, options);
             }
             else {
               module.error(error.noStorage);
@@ -452,8 +464,8 @@ $.fn.nag.settings = {
   value         : 'dismiss',
 
   error: {
-    noCookieStorage : '$.cookie is not included. A storage solution is required.',
-    noStorage       : 'Neither $.cookie or store is defined. A storage solution is required for storing state',
+    noCookieStorage : '$.cookie or Cookies is not included. A storage solution is required.',
+    noStorage       : 'Neither $.cookie, Cookies or store is defined. A storage solution is required for storing state',
     method          : 'The method you called is not defined.'
   },
 

--- a/src/definitions/modules/nag.js
+++ b/src/definitions/modules/nag.js
@@ -198,6 +198,7 @@ $.fn.nag = function(parameters) {
               $.cookie(key, value, options);
               module.debug('Value stored using cookie', key, value, options);
             }
+            // support for js-cookie
             else if(Cookies !== undefined) {
               Cookies.set(key, value, options);
               module.debug('Value stored using cookie', key, value, options);
@@ -218,7 +219,7 @@ $.fn.nag = function(parameters) {
             else if($.cookie !== undefined) {
               storedValue = $.cookie(key);
             }
-            // get by cookie
+            // get by js-cookie
             else if(Cookies !== undefined) {
               storedValue = Cookies.get(key);
             }
@@ -241,7 +242,7 @@ $.fn.nag = function(parameters) {
             else if($.cookie !== undefined) {
               $.removeCookie(key, options);
             }
-            // store by cookie
+            // store by js-cookie
             else if(Cookie !== undefined) {
               Cookies.remove(key, options);
             }


### PR DESCRIPTION
Since jquery-cookie is deprecated in favor or js-cookie, it would be good to be able to use either one.
See: https://github.com/js-cookie/js-cookie and https://github.com/carhartl/jquery-cookie