### PR TITLE
bugfix for ajax abort

### DIFF
--- a/dist/semantic.js
+++ b/dist/semantic.js
@@ -18367,7 +18367,7 @@ $.api = $.fn.api = function(parameters) {
               }
               setTimeout(function() {
                 if( module.is.abortedRequest(xhr) ) {
-                  module.request.rejectWith(context, [xhr, 'aborted', httpMessage]);
+                  //module.request.rejectWith(context, [xhr, 'aborted', httpMessage]);
                 }
                 else {
                   module.request.rejectWith(context, [xhr, 'error', status, httpMessage]);


### PR DESCRIPTION
simply skip the reject for abort will produce the expected behavior. See Issue #2779 .