### PR TITLE
[Nag] Fix issue with localstorage and add support for session storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Check out our [integration wiki](https://github.com/Semantic-Org/Semantic-UI/wik
 
 * Last 2 Versions FF, Chrome, IE 10+, Safari Mac
 * IE 10+
+* Android 4.4+, Chrome for Android 44+
+* iOS Safari 7+
 * Android 4
 
 Although some components will work in IE9, [grids](http://semantic-ui.com/collections/grid.html) and other [flexbox](https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Flexible_boxes) components are not supported by IE9 and may not appear correctly.

--- a/src/definitions/modules/nag.js
+++ b/src/definitions/modules/nag.js
@@ -226,7 +226,7 @@ $.fn.nag = function(parameters) {
             var
               options = module.get.storageOptions()
             ;
-            if(settings.storageMethod == 'local' && window.store !== undefined) {
+            if(settings.storageMethod == 'localstorage' && window.localStorage !== undefined) {
               window.localStorage.removeItem(key);
             }
             // store by cookie

--- a/src/definitions/modules/nag.js
+++ b/src/definitions/modules/nag.js
@@ -194,6 +194,10 @@ $.fn.nag = function(parameters) {
               window.localStorage.setItem(key, value);
               module.debug('Value stored using local storage', key, value);
             }
+            else if(settings.storageMethod == 'sessionstorage' && window.sessionStorage !== undefined) {
+              window.sessionStorage.setItem(key, value);
+              module.debug('Value stored using session storage', key, value);
+            }
             else if($.cookie !== undefined) {
               $.cookie(key, value, options);
               module.debug('Value stored using cookie', key, value, options);
@@ -209,6 +213,9 @@ $.fn.nag = function(parameters) {
             ;
             if(settings.storageMethod == 'localstorage' && window.localStorage !== undefined) {
               storedValue = window.localStorage.getItem(key);
+            }
+            else if(settings.storageMethod == 'sessionstorage' && window.sessionStorage !== undefined) {
+              storedValue = window.sessionStorage.getItem(key);
             }
             // get by cookie
             else if($.cookie !== undefined) {
@@ -228,6 +235,9 @@ $.fn.nag = function(parameters) {
             ;
             if(settings.storageMethod == 'localstorage' && window.localStorage !== undefined) {
               window.localStorage.removeItem(key);
+            }
+            else if(settings.storageMethod == 'sessionstorage' && window.sessionStorage !== undefined) {
+              window.sessionStorage.removeItem(key);
             }
             // store by cookie
             else if($.cookie !== undefined) {


### PR DESCRIPTION
Fixed an issue in Nag module > storage.remove which was checking `settings.storageMethod` with an incorrect value and was also checking `window` for a store property which does not exist.

Added support for sessionstorage to Nag module to enable nags to be shown once per session.