### PR TITLE
Fixed bad template url

### DIFF
--- a/src/definitions/modules/embed.js
+++ b/src/definitions/modules/embed.js
@@ -627,7 +627,7 @@ $.fn.embed.settings = {
   templates: {
     iframe : function(url, parameters) {
       return ''
-        + '<iframe src="' + url + '?=' + parameters + '"'
+        + '<iframe src="' + url + '?' + parameters + '"'
         + ' width="100%" height="100%"'
         + ' frameborder="0" scrolling="no" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>'
       ;


### PR DESCRIPTION
Equals after the question mark caused parameters not to be recognised by youtube.