### PR TITLE
[dropdown] Preserve initial disabled state

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -321,6 +321,10 @@ $.fn.dropdown = function(parameters) {
               if($input.is('[multiple]')) {
                 module.set.multiple();
               }
+              if ($input.prop('disabled')) {
+                module.debug('Disabling dropdown')
+                $module.addClass(className.disabled)
+              }
               $input
                 .removeAttr('class')
                 .detach()


### PR DESCRIPTION
ref: #2981 

Just add disabled state if the origin is disabled.

```html
<select class="ui dropdown" disabled>
</select>
```
to
```html
<div class="ui dropdown selection disabled">
</div>
```

test: https://jsbin.com/rapopus/edit?html,output