### PR TITLE
Allow <table> styling with any tags via classes .table, .tbody, .td, etc

### DIFF
--- a/src/definitions/collections/table.less
+++ b/src/definitions/collections/table.less
@@ -50,15 +50,19 @@
 
 /* Table Content */
 .ui.table th,
-.ui.table td {
+.ui.table td,
+.ui.table .th,
+.ui.table .td {
   transition: @transition;
 }
 
 /* Headers */
-.ui.table thead {
+.ui.table thead,
+.ui.table .thead {
   box-shadow: @headerBoxShadow;
 }
-.ui.table thead th {
+.ui.table thead th,
+.ui.table .thead .th {
   cursor: auto;
   background: @headerBackground;
   text-align: @headerAlign;
@@ -72,25 +76,31 @@
   border-left: @headerDivider;
 }
 
-.ui.table thead tr > th:first-child {
+.ui.table thead tr > th:first-child,
+.ui.table .thead .tr > .th:first-child {
   border-left: none;
 }
 
-.ui.table thead tr:first-child > th:first-child {
+.ui.table thead tr:first-child > th:first-child,
+.ui.table .thead .tr:first-child > .th:first-child {
   border-radius: @borderRadius 0em 0em 0em;
 }
-.ui.table thead tr:first-child > th:last-child {
+.ui.table thead tr:first-child > th:last-child,
+.ui.table .thead .tr:first-child > .th:last-child {
   border-radius: 0em @borderRadius 0em 0em;
 }
-.ui.table thead tr:first-child > th:only-child {
+.ui.table thead tr:first-child > th:only-child,
+.ui.table .thead .tr:first-child > .th:only-child {
   border-radius: @borderRadius @borderRadius 0em 0em;
 }
 
 /* Footer */
-.ui.table tfoot {
+.ui.table tfoot,
+.ui.table .tfoot {
   box-shadow: @footerBoxShadow;
 }
-.ui.table tfoot th {
+.ui.table tfoot th,
+.ui.table .tfoot .th {
   cursor: auto;
   border-top: @footerBorder;
   background: @footerBackground;
@@ -102,29 +112,36 @@
   font-weight: @footerFontWeight;
   text-transform: @footerTextTransform;
 }
-.ui.table tfoot tr > th:first-child {
+.ui.table tfoot tr > th:first-child,
+.ui.table .tfoot .tr > .th:first-child {
   border-left: none;
 }
-.ui.table tfoot tr:first-child > th:first-child {
+.ui.table tfoot tr:first-child > th:first-child,
+.ui.table .tfoot .tr:first-child > .th:first-child {
   border-radius: 0em 0em 0em @borderRadius;
 }
-.ui.table tfoot tr:first-child > th:last-child {
+.ui.table tfoot tr:first-child > th:last-child,
+.ui.table .tfoot .tr:first-child > .th:last-child {
   border-radius: 0em 0em @borderRadius 0em;
 }
-.ui.table tfoot tr:first-child > th:only-child {
+.ui.table tfoot tr:first-child > th:only-child,
+.ui.table .tfoot .tr:first-child > .th:only-child {
   border-radius: 0em 0em @borderRadius @borderRadius;
 }
 
 /* Table Row */
-.ui.table tr td {
+.ui.table tr td,
+.ui.table .tr .td {
   border-top: @rowBorder;
 }
-.ui.table tr:first-child td {
+.ui.table tr:first-child td,
+.ui.table .tr:first-child .td {
   border-top: none;
 }
 
 /* Table Cells */
-.ui.table td {
+.ui.table td,
+.ui.table .td {
   padding: @cellVerticalPadding @cellHorizontalPadding;
   text-align: @cellTextAlign;
 }
@@ -157,7 +174,11 @@
   .ui.table:not(.unstackable) tbody,
   .ui.table:not(.unstackable) tr,
   .ui.table:not(.unstackable) tr > th,
-  .ui.table:not(.unstackable) tr > td  {
+  .ui.table:not(.unstackable) tr > td,
+  .ui.table:not(.unstackable) .tbody,
+  .ui.table:not(.unstackable) .tr,
+  .ui.table:not(.unstackable) .tr > .th,
+  .ui.table:not(.unstackable) .tr > .td  {
     display: block !important;
     width: auto !important;
     display: block !important;
@@ -166,32 +187,40 @@
   .ui.table:not(.unstackable) {
     padding: 0em;
   }
-  .ui.table:not(.unstackable) thead {
+  .ui.table:not(.unstackable) thead,
+  .ui.table:not(.unstackable) .thead {
     display: @responsiveHeaderDisplay;
   }
-  .ui.table:not(.unstackable) tfoot {
+  .ui.table:not(.unstackable) tfoot,
+  .ui.table:not(.unstackable) .tfoot {
     display: @responsiveFooterDisplay;
   }
-  .ui.table:not(.unstackable) tr {
+  .ui.table:not(.unstackable) tr,
+  .ui.table:not(.unstackable) .tr {
     padding-top: @responsiveRowVerticalPadding;
     padding-bottom: @responsiveRowVerticalPadding;
     box-shadow: @responsiveRowBoxShadow;
   }
 
   .ui.table:not(.unstackable) tr > th,
-  .ui.table:not(.unstackable) tr > td {
+  .ui.table:not(.unstackable) tr > td,
+  .ui.table:not(.unstackable) .tr > .th,
+  .ui.table:not(.unstackable) .tr > .td, {
     background: none;
     border: none !important;
     padding: @responsiveCellVerticalPadding @responsiveCellHorizontalPadding !important;
     box-shadow: @responsiveCellBoxShadow;
   }
   .ui.table:not(.unstackable) th:first-child,
-  .ui.table:not(.unstackable) td:first-child {
+  .ui.table:not(.unstackable) td:first-child,
+  .ui.table:not(.unstackable) .th:first-child,
+  .ui.table:not(.unstackable) .td:first-child {
     font-weight: bold;
   }
 
   /* Definition Table */
-  .ui.definition.table:not(.unstackable) thead th:first-child {
+  .ui.definition.table:not(.unstackable) thead th:first-child,
+  .ui.definition.table:not(.unstackable) .thead .th:first-child {
     box-shadow: none !important;
   }
 }
@@ -205,7 +234,11 @@
 .ui.table th .image,
 .ui.table th .image img,
 .ui.table td .image,
-.ui.table td .image img {
+.ui.table td .image img,
+.ui.table .th .image,
+.ui.table .th .image img,
+.ui.table .td .image,
+.ui.table .td .image img {
   max-width: none;
 }
 
@@ -221,20 +254,25 @@
 .ui.structured.table {
   border-collapse: collapse;
 }
-.ui.structured.table thead th {
+.ui.structured.table thead th,
+.ui.structured.table .thead .th {
   border-left: @headerDivider;
   border-right: @headerDivider;
 }
-.ui.structured.sortable.table thead th {
+.ui.structured.sortable.table thead th,
+.ui.structured.sortable.table .thead .th {
   border-left: @sortableBorder;
   border-right: @sortableBorder;
 }
-.ui.structured.basic.table th {
+.ui.structured.basic.table th,
+.ui.structured.basic.table .th {
   border-left: @basicTableHeaderDivider;
   border-right: @basicTableHeaderDivider;
 }
 .ui.structured.celled.table tr th,
-.ui.structured.celled.table tr td {
+.ui.structured.celled.table tr td,
+.ui.structured.celled.table .tr .th,
+.ui.structured.celled.table .tr .td {
   border-left: @cellBorder;
   border-right: @cellBorder;
 }
@@ -243,7 +281,8 @@
    Definition
 ---------------*/
 
-.ui.definition.table thead:not(.full-width) th:first-child {
+.ui.definition.table thead:not(.full-width) th:first-child,
+.ui.definition.table .thead:not(.full-width) .th:first-child {
   pointer-events: none;
   background: @definitionHeaderBackground;
   font-weight: @definitionHeaderFontWeight;
@@ -251,7 +290,8 @@
   box-shadow: -@borderWidth -@borderWidth 0px @borderWidth @definitionPageBackground;
 }
 
-.ui.definition.table tfoot:not(.full-width) th:first-child {
+.ui.definition.table tfoot:not(.full-width) th:first-child,
+.ui.definition.table .tfoot:not(.full-width) .th:first-child {
   pointer-events: none;
   background: @definitionFooterBackground;
   font-weight: @definitionFooterColor;
@@ -260,28 +300,34 @@
 }
 
 /* Remove Border */
-.ui.celled.definition.table thead:not(.full-width) th:first-child {
+.ui.celled.definition.table thead:not(.full-width) th:first-child,
+.ui.celled.definition.table .thead:not(.full-width) .th:first-child {
   box-shadow: 0px -@borderWidth 0px @borderWidth @definitionPageBackground;
 }
-.ui.celled.definition.table tfoot:not(.full-width) th:first-child {
+.ui.celled.definition.table tfoot:not(.full-width) th:first-child,
+.ui.celled.definition.table .tfoot:not(.full-width) .th:first-child {
   box-shadow: 0px @borderWidth 0px @borderWidth @definitionPageBackground;
 }
 
 /* Highlight Defining Column */
-.ui.definition.table tr td:first-child {
+.ui.definition.table tr td:first-child,
+.ui.definition.table .tr .td:first-child {
   background: @definitionColumnBackground;
   font-weight: @definitionColumnFontWeight;
   color: @definitionColumnColor;
 }
 
 /* Fix 2nd Column */
-.ui.definition.table thead:not(.full-width) th:nth-child(2) {
+.ui.definition.table thead:not(.full-width) th:nth-child(2),
+.ui.definition.table .thead:not(.full-width) .th:nth-child(2) {
   border-left: @borderWidth solid @borderColor;
 }
-.ui.definition.table tfoot:not(.full-width) th:nth-child(2) {
+.ui.definition.table tfoot:not(.full-width) th:nth-child(2),
+.ui.definition.table .tfoot:not(.full-width) .th:nth-child(2) {
   border-left: @borderWidth solid @borderColor;
 }
-.ui.definition.table td:nth-child(2) {
+.ui.definition.table td:nth-child(2),
+.ui.definition.table .td:nth-child(2) {
   border-left: @borderWidth solid @borderColor;
 }
 
@@ -295,11 +341,15 @@
 ---------------*/
 
 .ui.table tr.positive,
-.ui.table td.positive {
+.ui.table td.positive,
+.ui.table .tr.positive,
+.ui.table .td.positive {
   box-shadow: @positiveBoxShadow;
 }
 .ui.table tr.positive,
-.ui.table td.positive {
+.ui.table td.positive,
+.ui.table .tr.positive,
+.ui.table .td.positive {
   background: @positiveBackgroundColor !important;
   color: @positiveColor !important;
 }
@@ -309,11 +359,15 @@
 ---------------*/
 
 .ui.table tr.negative,
-.ui.table td.negative {
+.ui.table td.negative,
+.ui.table .tr.negative,
+.ui.table .td.negative {
   box-shadow: @negativeBoxShadow;
 }
 .ui.table tr.negative,
-.ui.table td.negative {
+.ui.table td.negative,
+.ui.table .tr.negative,
+.ui.table .td.negative {
   background: @negativeBackgroundColor !important;
   color: @negativeColor !important;
 }
@@ -323,11 +377,15 @@
 ---------------*/
 
 .ui.table tr.error,
-.ui.table td.error {
+.ui.table td.error,
+.ui.table .tr.error,
+.ui.table .td.error {
   box-shadow: @errorBoxShadow;
 }
 .ui.table tr.error,
-.ui.table td.error {
+.ui.table td.error,
+.ui.table .tr.error,
+.ui.table .td.error {
   background: @errorBackgroundColor !important;
   color: @errorColor !important;
 }
@@ -336,11 +394,15 @@
 ---------------*/
 
 .ui.table tr.warning,
-.ui.table td.warning {
+.ui.table td.warning,
+.ui.table .tr.warning,
+.ui.table .td.warning {
   box-shadow: @warningBoxShadow;
 }
 .ui.table tr.warning,
-.ui.table td.warning {
+.ui.table td.warning,
+.ui.table .tr.warning,
+.ui.table .td.warning {
   background: @warningBackgroundColor !important;
   color: @warningColor !important;
 }
@@ -350,11 +412,15 @@
 ---------------*/
 
 .ui.table tr.active,
-.ui.table td.active {
+.ui.table td.active,
+.ui.table .tr.active,
+.ui.table .td.active {
   box-shadow: @activeBoxShadow;
 }
 .ui.table tr.active,
-.ui.table td.active {
+.ui.table td.active,
+.ui.table .tr.active,
+.ui.table .td.active {
   background: @activeBackgroundColor !important;
   color: @activeColor !important;
 }
@@ -368,7 +434,11 @@
 .ui.table tr.disabled td,
 .ui.table tr td.disabled,
 .ui.table tr.disabled:hover,
-.ui.table tr:hover td.disabled {
+.ui.table tr:hover td.disabled,
+.ui.table .tr.disabled .td,
+.ui.table .tr .td.disabled,
+.ui.table .tr.disabled:hover,
+.ui.table .tr:hover .td.disabled {
   pointer-events: none;
   color: @disabledTextColor;
 }
@@ -387,7 +457,12 @@
   .ui[class*="tablet stackable"].table tbody,
   .ui[class*="tablet stackable"].table tr,
   .ui[class*="tablet stackable"].table tr > th,
-  .ui[class*="tablet stackable"].table tr > td  {
+  .ui[class*="tablet stackable"].table tr > td,
+  .ui[class*="tablet stackable"].table,
+  .ui[class*="tablet stackable"].table .tbody,
+  .ui[class*="tablet stackable"].table .tr,
+  .ui[class*="tablet stackable"].table .tr > .th,
+  .ui[class*="tablet stackable"].table .tr > .td {
     display: block !important;
     width: 100% !important;
     display: block !important;
@@ -396,19 +471,24 @@
   .ui[class*="tablet stackable"].table {
     padding: 0em;
   }
-  .ui[class*="tablet stackable"].table thead {
+  .ui[class*="tablet stackable"].table thead,
+  .ui[class*="tablet stackable"].table .thead {
     display: @responsiveHeaderDisplay;
   }
-  .ui[class*="tablet stackable"].table tfoot {
+  .ui[class*="tablet stackable"].table tfoot,
+  .ui[class*="tablet stackable"].table .tfoot {
     display: @responsiveFooterDisplay;
   }
-  .ui[class*="tablet stackable"].table tr {
+  .ui[class*="tablet stackable"].table tr,
+  .ui[class*="tablet stackable"].table .tr {
     padding-top: @responsiveRowVerticalPadding;
     padding-bottom: @responsiveRowVerticalPadding;
     box-shadow: @responsiveRowBoxShadow;
   }
   .ui[class*="tablet stackable"].table tr > th,
-  .ui[class*="tablet stackable"].table tr > td {
+  .ui[class*="tablet stackable"].table tr > td,
+  .ui[class*="tablet stackable"].table .tr > .th,
+  .ui[class*="tablet stackable"].table .tr > .td {
     background: none;
     border: none !important;
     padding: @responsiveCellVerticalPadding @responsiveCellHorizontalPadding;
@@ -416,7 +496,8 @@
   }
 
   /* Definition Table */
-  .ui.definition[class*="tablet stackable"].table thead th:first-child {
+  .ui.definition[class*="tablet stackable"].table thead th:first-child,
+  .ui.definition[class*="tablet stackable"].table .thead .th:first-child {
     box-shadow: none !important;
   }
 }
@@ -460,7 +541,9 @@
 ---------------*/
 
 .ui.table th.collapsing,
-.ui.table td.collapsing {
+.ui.table td.collapsing,
+.ui.table .th.collapsing,
+.ui.table .td.collapsing {
   width: 1px;
   white-space: nowrap;
 }
@@ -474,7 +557,9 @@
 }
 
 .ui.fixed.table th,
-.ui.fixed.table td {
+.ui.fixed.table td,
+.ui.fixed.table .th,
+.ui.fixed.table .td {
   overflow: hidden;
   text-overflow: ellipsis;
 }
@@ -484,38 +569,50 @@
    Hoverable
 ---------------*/
 
-.ui.selectable.table tbody tr:hover {
+.ui.selectable.table tbody tr:hover,
+.ui.selectable.table tbody .tr:hover {
   background: @selectableBackground !important;
   color: @selectableTextColor !important;
 }
-.ui.selectable.inverted.table tbody tr:hover {
+.ui.selectable.inverted.table tbody tr:hover,
+.ui.selectable.inverted.table .tbody .tr:hover {
   background: @selectableInvertedBackground !important;
   color: @selectableInvertedTextColor !important;
 }
 
 /* Other States */
 .ui.selectable.table tr.error:hover,
-.ui.selectable.table tr:hover td.error {
+.ui.selectable.table tr:hover td.error,
+.ui.selectable.table .tr.error:hover,
+.ui.selectable.table .tr:hover .td.error {
   background: @errorBackgroundHover !important;
   color: @errorColorHover !important;
 }
 .ui.selectable.table tr.warning:hover,
-.ui.selectable.table tr:hover td.warning {
+.ui.selectable.table tr:hover td.warning,
+.ui.selectable.table .tr.warning:hover,
+.ui.selectable.table .tr:hover .td.warning {
   background: @warningBackgroundHover !important;
   color: @warningColorHover !important;
 }
 .ui.selectable.table tr.active:hover,
-.ui.selectable.table tr:hover td.active {
+.ui.selectable.table tr:hover td.active,
+.ui.selectable.table .tr.active:hover,
+.ui.selectable.table .tr:hover .td.active {
   background: @activeBackgroundColor !important;
   color: @activeColor !important;
 }
 .ui.selectable.table tr.positive:hover,
-.ui.selectable.table tr:hover td.positive {
+.ui.selectable.table tr:hover td.positive,
+.ui.selectable.table .tr.positive:hover,
+.ui.selectable.table .tr:hover .td.positive {
   background: @positiveBackgroundHover !important;
   color: @positiveColorHover !important;
 }
 .ui.selectable.table tr.negative:hover,
-.ui.selectable.table tr:hover td.negative {
+.ui.selectable.table tr:hover td.negative,
+.ui.selectable.table .tr.negative:hover,
+.ui.selectable.table .tr:hover .td.negative {
   background: @negativeBackgroundHover !important;
   color: @negativeColorHover !important;
 }
@@ -571,13 +668,17 @@
 
 /* Table Striping */
 .ui.striped.table > tr:nth-child(2n),
-.ui.striped.table tbody tr:nth-child(2n) {
+.ui.striped.table tbody tr:nth-child(2n),
+.ui.striped.table > .tr:nth-child(2n),
+.ui.striped.table .tbody .tr:nth-child(2n) {
   background-color: @stripedBackground;
 }
 
 /* Stripes */
 .ui.inverted.striped.table > tr:nth-child(2n),
-.ui.inverted.striped.table tbody tr:nth-child(2n) {
+.ui.inverted.striped.table tbody tr:nth-child(2n),
+.ui.inverted.striped.table > .tr:nth-child(2n),
+.ui.inverted.striped.table .tbody .tr:nth-child(2n) {
   background-color: @invertedStripedBackground;
 }
 
@@ -721,118 +822,166 @@
 ---------------*/
 
 /* Grid Based */
-.ui.one.column.table td {
+.ui.one.column.table td,
+.ui.one.column.table .td {
   width: @oneColumn;
 }
-.ui.two.column.table td {
+.ui.two.column.table td,
+.ui.two.column.table .td {
   width: @twoColumn;
 }
-.ui.three.column.table td {
+.ui.three.column.table td,
+.ui.three.column.table .td {
   width: @threeColumn;
 }
-.ui.four.column.table td {
+.ui.four.column.table td,
+.ui.four.column.table .td {
   width: @fourColumn;
 }
-.ui.five.column.table td {
+.ui.five.column.table td,
+.ui.five.column.table .td {
   width: @fiveColumn;
 }
-.ui.six.column.table td {
+.ui.six.column.table td,
+.ui.six.column.table .td {
   width: @sixColumn;
 }
-.ui.seven.column.table td {
+.ui.seven.column.table td,
+.ui.seven.column.table .td {
   width: @sevenColumn;
 }
-.ui.eight.column.table td {
+.ui.eight.column.table td,
+.ui.eight.column.table .td {
   width: @eightColumn;
 }
-.ui.nine.column.table td {
+.ui.nine.column.table td,
+.ui.nine.column.table .td {
   width: @nineColumn;
 }
-.ui.ten.column.table td {
+.ui.ten.column.table td,
+.ui.ten.column.table .td {
   width: @tenColumn;
 }
-.ui.eleven.column.table td {
+.ui.eleven.column.table td,
+.ui.eleven.column.table .td {
   width: @elevenColumn;
 }
-.ui.twelve.column.table td {
+.ui.twelve.column.table td,
+.ui.twelve.column.table .td {
   width: @twelveColumn;
 }
-.ui.thirteen.column.table td {
+.ui.thirteen.column.table td,
+.ui.thirteen.column.table .td {
   width: @thirteenColumn;
 }
-.ui.fourteen.column.table td {
+.ui.fourteen.column.table td,
+.ui.fourteen.column.table .td {
   width: @fourteenColumn;
 }
-.ui.fifteen.column.table td {
+.ui.fifteen.column.table td,
+.ui.fifteen.column.table .td {
   width: @fifteenColumn;
 }
-.ui.sixteen.column.table td {
+.ui.sixteen.column.table td,
+.ui.sixteen.column.table .td {
   width: @sixteenColumn;
 }
 
 /* Column Width */
 .ui.table th.one.wide,
-.ui.table td.one.wide {
+.ui.table td.one.wide,
+.ui.table .th.one.wide,
+.ui.table .td.one.wide {
   width: @oneWide;
 }
 .ui.table th.two.wide,
-.ui.table td.two.wide {
+.ui.table td.two.wide,
+.ui.table .th.two.wide,
+.ui.table .td.two.wide {
   width: @twoWide;
 }
 .ui.table th.three.wide,
-.ui.table td.three.wide {
+.ui.table td.three.wide,
+.ui.table .th.three.wide,
+.ui.table .td.three.wide {
   width: @threeWide;
 }
 .ui.table th.four.wide,
-.ui.table td.four.wide {
+.ui.table td.four.wide,
+.ui.table .th.four.wide,
+.ui.table .td.four.wide {
   width: @fourWide;
 }
 .ui.table th.five.wide,
-.ui.table td.five.wide {
+.ui.table td.five.wide,
+.ui.table .th.five.wide,
+.ui.table .td.five.wide {
   width: @fiveWide;
 }
 .ui.table th.six.wide,
-.ui.table td.six.wide {
+.ui.table td.six.wide,
+.ui.table .th.six.wide,
+.ui.table .td.six.wide {
   width: @sixWide;
 }
 .ui.table th.seven.wide,
-.ui.table td.seven.wide {
+.ui.table td.seven.wide,
+.ui.table .th.seven.wide,
+.ui.table .td.seven.wide {
   width: @sevenWide;
 }
 .ui.table th.eight.wide,
-.ui.table td.eight.wide {
+.ui.table td.eight.wide,
+.ui.table .th.eight.wide,
+.ui.table .td.eight.wide {
   width: @eightWide;
 }
 .ui.table th.nine.wide,
-.ui.table td.nine.wide {
+.ui.table td.nine.wide,
+.ui.table .th.nine.wide,
+.ui.table .td.nine.wide {
   width: @nineWide;
 }
 .ui.table th.ten.wide,
-.ui.table td.ten.wide {
+.ui.table td.ten.wide,
+.ui.table .th.ten.wide,
+.ui.table .td.ten.wide {
   width: @tenWide;
 }
 .ui.table th.eleven.wide,
-.ui.table td.eleven.wide {
+.ui.table td.eleven.wide,
+.ui.table .th.eleven.wide,
+.ui.table .td.eleven.wide {
   width: @elevenWide;
 }
 .ui.table th.twelve.wide,
-.ui.table td.twelve.wide {
+.ui.table td.twelve.wide,
+.ui.table .th.twelve.wide,
+.ui.table .td.twelve.wide {
   width: @twelveWide;
 }
 .ui.table th.thirteen.wide,
-.ui.table td.thirteen.wide {
+.ui.table td.thirteen.wide,
+.ui.table .th.thirteen.wide,
+.ui.table .td.thirteen.wide {
   width: @thirteenWide;
 }
 .ui.table th.fourteen.wide,
-.ui.table td.fourteen.wide {
+.ui.table td.fourteen.wide,
+.ui.table .th.fourteen.wide,
+.ui.table .td.fourteen.wide {
   width: @fourteenWide;
 }
 .ui.table th.fifteen.wide,
-.ui.table td.fifteen.wide {
+.ui.table td.fifteen.wide,
+.ui.table .th.fifteen.wide,
+.ui.table .td.fifteen.wide {
   width: @fifteenWide;
 }
 .ui.table th.sixteen.wide,
-.ui.table td.sixteen.wide {
+.ui.table td.sixteen.wide,
+.ui.table .th.sixteen.wide,
+.ui.table .td.sixteen.wide {
   width: @sixteenWide;
 }
 
@@ -840,21 +989,26 @@
     Sortable
 ---------------*/
 
-.ui.sortable.table thead th {
+.ui.sortable.table thead th,
+.ui.sortable.table .thead .th {
   cursor: pointer;
   white-space: nowrap;
   border-left: @sortableBorder;
   color: @sortableColor;
 }
-.ui.sortable.table thead th:first-child {
+.ui.sortable.table thead th:first-child,
+.ui.sortable.table .thead .th:first-child {
   border-left: none;
 }
 .ui.sortable.table thead th.sorted,
-.ui.sortable.table thead th.sorted:hover {
+.ui.sortable.table .thead .th.sorted,
+.ui.sortable.table thead th.sorted:hover,
+.ui.sortable.table .thead .th.sorted:hover {
   user-select: none;
 }
 
-.ui.sortable.table thead th:after {
+.ui.sortable.table thead th:after,
+.ui.sortable.table .thead .th:after {
   display: none;
   font-style: normal;
   font-weight: normal;
@@ -866,48 +1020,58 @@
   margin: 0em 0em 0em @sortableIconDistance;
   font-family: @sortableIconFont;
 }
-.ui.sortable.table thead th.ascending:after {
+.ui.sortable.table thead th.ascending:after,
+.ui.sortable.table .thead .th.ascending:after {
   content: @sortableIconAscending;
 }
-.ui.sortable.table thead th.descending:after {
+.ui.sortable.table thead th.descending:after,
+.ui.sortable.table .thead .th.descending:after {
   content: @sortableIconDescending;
 }
 
 /* Hover */
-.ui.sortable.table th.disabled:hover {
+.ui.sortable.table th.disabled:hover,
+.ui.sortable.table .th.disabled:hover {
   cursor: auto;
   color: @sortableDisabledColor;
 }
-.ui.sortable.table thead th:hover {
+.ui.sortable.table thead th:hover,
+.ui.sortable.table .thead .th:hover {
   background: @sortableHoverBackground;
   color: @sortableHoverColor;
 }
 
 /* Sorted */
-.ui.sortable.table thead th.sorted {
+.ui.sortable.table thead th.sorted,
+.ui.sortable.table .thead .th.sorted {
   background: @sortableActiveBackground;
   color: @sortableActiveColor;
 }
-.ui.sortable.table thead th.sorted:after {
+.ui.sortable.table thead th.sorted:after,
+.ui.sortable.table .thead .th.sorted:after {
   display: inline-block;
 }
 
 /* Sorted Hover */
-.ui.sortable.table thead th.sorted:hover {
+.ui.sortable.table thead th.sorted:hover,
+.ui.sortable.table .thead .th.sorted:hover {
   background: @sortableActiveHoverBackground;
   color: @sortableActiveHoverColor;
 }
 
 /* Inverted */
-.ui.inverted.sortable.table thead th.sorted {
+.ui.inverted.sortable.table thead th.sorted,
+.ui.inverted.sortable.table .thead .th.sorted {
   background: @sortableInvertedActiveBackground;
   color: @sortableInvertedActiveColor;
 }
-.ui.inverted.sortable.table thead th:hover {
+.ui.inverted.sortable.table thead th:hover,
+.ui.inverted.sortable.table .thead .th:hover {
   background: @sortableInvertedHoverBackground;
   color: @sortableInvertedHoverColor;
 }
-.ui.inverted.sortable.table thead th {
+.ui.inverted.sortable.table thead th,
+.ui.inverted.sortable.table .thead .th {
   border-left-color: @sortableInvertedBorderColor;
   border-right-color: @sortableInvertedBorderColor;
 }
@@ -923,29 +1087,39 @@
   color: @invertedCellColor;
   border: @invertedBorder;
 }
-.ui.inverted.table th {
+.ui.inverted.table th,
+.ui.inverted.table .th {
   background-color: @invertedHeaderBackground;
   border-color: @invertedHeaderBorderColor !important;
   color: @invertedHeaderColor;
 }
-.ui.inverted.table tr td {
+.ui.inverted.table tr td,
+.ui.inverted.table .tr .td {
   border-color: @invertedCellBorderColor !important;
 }
 
 .ui.inverted.table tr.disabled td,
 .ui.inverted.table tr td.disabled,
 .ui.inverted.table tr.disabled:hover td,
-.ui.inverted.table tr:hover td.disabled {
+.ui.inverted.table tr:hover td.disabled,
+
+.ui.inverted.table .tr.disabled .td,
+.ui.inverted.table .tr .td.disabled,
+.ui.inverted.table .tr.disabled:hover .td,
+.ui.inverted.table .tr:hover .td.disabled {
   pointer-events: none;
   color: @invertedDisabledTextColor;
 }
 
 /* Definition */
 .ui.inverted.definition.table tfoot:not(.full-width) th:first-child,
-.ui.inverted.definition.table thead:not(.full-width) th:first-child {
+.ui.inverted.definition.table thead:not(.full-width) th:first-child,
+.ui.inverted.definition.table .tfoot:not(.full-width) .th:first-child,
+.ui.inverted.definition.table .thead:not(.full-width) .th:first-child {
   background: @definitionPageBackground;
 }
-.ui.inverted.definition.table tr td:first-child {
+.ui.inverted.definition.table tr td:first-child,
+.ui.inverted.definition.table .tr .td:first-child {
   background: @invertedDefinitionColumnBackground;
   color: @invertedDefinitionColumnColor;
 }
@@ -968,20 +1142,26 @@
   box-shadow: @basicBoxShadow;
 }
 .ui.basic.table thead,
-.ui.basic.table tfoot {
+.ui.basic.table tfoot,
+.ui.basic.table .thead,
+.ui.basic.table .tfoot {
   box-shadow: none;
 }
-.ui.basic.table th {
+.ui.basic.table th,
+.ui.basic.table .th {
   background: @basicTableHeaderBackground;
   border-left: @basicTableHeaderDivider;
 }
-.ui.basic.table tbody tr {
+.ui.basic.table tbody tr,
+.ui.basic.table .tbody .tr {
   border-bottom: @basicTableCellBorder;
 }
-.ui.basic.table td {
+.ui.basic.table td,
+.ui.basic.table .td {
   background: @basicTableCellBackground;
 }
-.ui.basic.striped.table tbody tr:nth-child(2n) {
+.ui.basic.striped.table tbody tr:nth-child(2n),
+.ui.basic.striped.table .tbody .tr:nth-child(2n) {
   background-color: @basicTableStripedBackground !important;
 }
 
@@ -990,18 +1170,25 @@
   border: none;
 }
 .ui[class*="very basic"].table:not(.sortable):not(.striped) th,
-.ui[class*="very basic"].table:not(.sortable):not(.striped) td {
+.ui[class*="very basic"].table:not(.sortable):not(.striped) td,
+.ui[class*="very basic"].table:not(.sortable):not(.striped) .th,
+.ui[class*="very basic"].table:not(.sortable):not(.striped) .td {
   padding: @basicTableCellPadding;
 }
 .ui[class*="very basic"].table:not(.sortable):not(.striped) th:first-child,
-.ui[class*="very basic"].table:not(.sortable):not(.striped) td:first-child {
+.ui[class*="very basic"].table:not(.sortable):not(.striped) td:first-child,
+.ui[class*="very basic"].table:not(.sortable):not(.striped) .th:first-child,
+.ui[class*="very basic"].table:not(.sortable):not(.striped) .td:first-child {
   padding-left: 0em;
 }
 .ui[class*="very basic"].table:not(.sortable):not(.striped) th:last-child,
-.ui[class*="very basic"].table:not(.sortable):not(.striped) td:last-child {
+.ui[class*="very basic"].table:not(.sortable):not(.striped) td:last-child,
+.ui[class*="very basic"].table:not(.sortable):not(.striped) .th:last-child,
+.ui[class*="very basic"].table:not(.sortable):not(.striped) .td:last-child {
   padding-right: 0em;
 }
-.ui[class*="very basic"].table:not(.sortable):not(.striped) thead tr:first-child th {
+.ui[class*="very basic"].table:not(.sortable):not(.striped) thead tr:first-child th,
+.ui[class*="very basic"].table:not(.sortable):not(.striped) .thead .tr:first-child .th {
   padding-top: 0em;
 }
 
@@ -1010,11 +1197,15 @@
 ---------------*/
 
 .ui.celled.table tr th,
-.ui.celled.table tr td {
+.ui.celled.table tr td,
+.ui.celled.table .tr .th,
+.ui.celled.table .tr .td {
   border-left: @cellBorder;
 }
 .ui.celled.table tr th:first-child,
-.ui.celled.table tr td:first-child {
+.ui.celled.table tr td:first-child,
+.ui.celled.table .tr .th:first-child,
+.ui.celled.table .tr .td:first-child {
   border-left: none;
 }
 
@@ -1022,21 +1213,26 @@
      Padded
 ---------------*/
 
-.ui.padded.table th {
+.ui.padded.table th,
+.ui.padded.table .th {
   padding-left: @paddedHorizontalPadding;
   padding-right: @paddedHorizontalPadding;
 }
 .ui.padded.table th,
-.ui.padded.table td {
+.ui.padded.table td,
+.ui.padded.table .th,
+.ui.padded.table .td {
   padding: @paddedVerticalPadding @paddedHorizontalPadding;
 }
 
 /* Very */
-.ui[class*="very padded"].table th {
+.ui[class*="very padded"].table th,
+.ui[class*="very padded"].table .th {
   padding-left: @veryPaddedHorizontalPadding;
   padding-right: @veryPaddedHorizontalPadding;
 }
-.ui[class*="very padded"].table td {
+.ui[class*="very padded"].table td,
+.ui[class*="very padded"].table .td {
   padding: @veryPaddedVerticalPadding @veryPaddedHorizontalPadding;
 }
 
@@ -1044,20 +1240,24 @@
      Compact
 ---------------*/
 
-.ui.compact.table th {
+.ui.compact.table th,
+.ui.compact.table .th {
   padding-left: @compactHorizontalPadding;
   padding-right: @compactHorizontalPadding;
 }
-.ui.compact.table td {
+.ui.compact.table td,
+.ui.compact.table .td {
   padding: @compactVerticalPadding @compactHorizontalPadding;
 }
 
 /* Very */
-.ui[class*="very compact"].table th {
+.ui[class*="very compact"].table th,
+.ui[class*="very compact"].table .th {
   padding-left: @veryCompactHorizontalPadding;
   padding-right: @veryCompactHorizontalPadding;
 }
-.ui[class*="very compact"].table td {
+.ui[class*="very compact"].table td,
+.ui[class*="very compact"].table .td {
   padding: @veryCompactVerticalPadding @veryCompactHorizontalPadding;
 }
 


### PR DESCRIPTION
Applying the table style currently depends on you actually using a real `<table>` and its descendants.

```html
<table class="ui table">
  <thead>
    <tr>
      <th>Header</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Cell</td>
    </tr>
  </tbody>
</table>
```
Proposed opt-in/typecast class names:

```html
<div class="ui table">
  <div class="thead">
    <div class="tr">
      <div class="th">Header</div>
    </div>
  </div>
  <div class="tbody">
    <div class="tr">
      <div class="td">Cell</div>
    </div>
  </div>
</div>
```

Pros: Works with any number of infinite scroll table components that do not use a real `<table>`.
Cons: Increases overall filesize about 7 KB minified.

Flame on. :fire: :fire: 