### PR TITLE
Adding support for data-text when using dropdown with API requests

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -3386,10 +3386,7 @@ $.fn.dropdown.settings.templates = {
 
   // generates just menu from select
   menu: function(response, fields) {
-    var
-      values = response.values || {},
-      html   = ''
-    ;
+    var html   = '';
     $.each(response[fields.values], function(index, option) {
       html += '<div class="item" data-value="' + option[fields.value] + '">' + option[fields.name] + '</div>';
     });

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -3312,6 +3312,7 @@ $.fn.dropdown.settings = {
   fields: {
     values : 'values', // grouping for all dropdown values
     name   : 'name',   // displayed dropdown text
+    text   : 'text',   // displayed label text
     value  : 'value'   // actual dropdown value
   },
 
@@ -3388,7 +3389,11 @@ $.fn.dropdown.settings.templates = {
   menu: function(response, fields) {
     var html   = '';
     $.each(response[fields.values], function(index, option) {
-      html += '<div class="item" data-value="' + option[fields.value] + '">' + option[fields.name] + '</div>';
+      html += '<div class="item" data-value="' + option[fields.value] + '"';
+      if (option[fields.text]) {
+        html += ' data-text="' + option[fields.text] + '"';
+      }
+      html += '>' + option[fields.name] + '</div>';
     });
     return html;
   },


### PR DESCRIPTION
See: http://semantic-ui.com/modules/dropdown.html#specifying-different-text--hidden-input-values

There was no way to include `data-text` when using `dropdown` and populating it with the API. This will conditionally add it if it is contained in the response results.

Additionally, the `values` variable was not being used.