### PR TITLE
[Search] Replaced usage of `response` variable by `result` variable to set URL on result item

### DIFF
--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -1262,8 +1262,8 @@ $.fn.search.settings = {
 
         // each result
         $.each(response[fields.results], function(index, result) {
-          if(response[fields.url]) {
-            html  += '<a class="result" href="' + response[fields.url] + '">';
+          if(result[fields.url]) {
+            html  += '<a class="result" href="' + result[fields.url] + '">';
           }
           else {
             html  += '<a class="result">';


### PR DESCRIPTION
Hi,

It seems the wrong variable is used to build and affect associated URL to results in search module. Without that change, it is impossible to associate a specific URL per result. Because other values are found on result variable it seems logical to use the choosen field on `result`variable and not on `response` variable.