### PR TITLE
Fix error on blur

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -299,7 +299,9 @@ $.fn.form = function(parameters) {
                 module.validate.form.call(module, event, true);
               }
               else if(settings.on == 'blur' || settings.on == 'change') {
-                module.validate.field( validationRules );
+                if( validationRules ) {
+                  module.validate.field( validationRules );  
+                }
               }
             },
             change: function(event) {


### PR DESCRIPTION
@jlukic see https://jsfiddle.net/b21sgvkk/2/
1. click on button
2. click in ```email``` field
3. click on button
4. see console 
```
Uncaught TypeError: Cannot assign to read only property 'identifier' of falsemodule.validate.field @ semantic.js:1294module.event.field.blur @ semantic.js:800jQuery.event.dispatch @ jquery-2.1.3.js:4430elemData.handle @ jquery-2.1.3.js:4116jQuery.event.trigger @ jquery-2.1.3.js:4345jQuery.event.simulate @ jquery-2.1.3.js:4647handler @ jquery-2.1.3.js:4775
```