### PR TITLE
Changed several gulp tasks to correctly handle async pipe

### DIFF
--- a/tasks/build/assets.js
+++ b/tasks/build/assets.js
@@ -27,9 +27,10 @@ module.exports = function(callback) {
   console.info('Building assets');
 
   // copy assets
-  return gulp.src(source.themes + '/**/assets/**/*.*')
+  gulp.src(source.themes + '/**/assets/**/*.*')
     .pipe(gulpif(config.hasPermission, chmod(config.permission)))
     .pipe(gulp.dest(output.themes))
+    .on('end', callback)
   ;
 
 };

--- a/tasks/build/javascript.js
+++ b/tasks/build/javascript.js
@@ -18,6 +18,7 @@ var
   rename       = require('gulp-rename'),
   replace      = require('gulp-replace'),
   uglify       = require('gulp-uglify'),
+  runSequence  = require('run-sequence'),
 
   // config
   config       = require('../config/user'),
@@ -41,12 +42,6 @@ require('../collections/internal')(gulp);
 
 module.exports = function(callback) {
 
-  var
-    stream,
-    compressedStream,
-    uncompressedStream
-  ;
-
   console.info('Building Javascript');
 
   if( !install.isSetup() ) {
@@ -68,9 +63,10 @@ module.exports = function(callback) {
     .pipe(gulpif(config.hasPermission, chmod(config.permission)))
     .pipe(print(log.created))
     .on('end', function() {
-      gulp.start('package compressed js');
-      gulp.start('package uncompressed js');
-      callback();
+      runSequence(
+        ['package compressed js', 'package uncompressed js'],
+        callback
+      );
     })
   ;
 

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -228,4 +228,5 @@ module.exports = function(callback) {
     })
   ;
 
+  callback();
 };


### PR DESCRIPTION
Without this change the following code wouldn't work as expected:

``` javascript
gulp.task('dev-semantic-styles', function() {
  return gulp.src('./semantic/dist/semantic.css')
    .pipe(changed('./dist'))
    .pipe(gulp.dest('./dist/semantic'));
});
// ... omitted the other tasks that copies styles and assets to different directory ...
gulp.task('dev-copy-semantic', function(callback) {
  runSequence(
    ['ui-js', 'ui-css', 'ui-assets'],  // the tasks imported from semantic
    ['dev-semantic-js', 'dev-semantic-styles', 'dev-semantic-assets'],  // our tasks that should run after semantic
    callback
  );
});
gulp.task('build', function(callback) {
  runSequence(
    'clean',
    [
      // lot of other tasks...
      'dev-copy-semantic'
    ],
    callback
  );
});
```

If I run `gulp build` with the original code, the ui-js and ui-css tasks does not finish before running my dev-\* tasks. 
The reason is the use of `gulp.start` method in the `on.('end', ...)` event handler, that forks new async tasks without completion notification.

The proposed change addresses this issue and makes integration of semantic's tasks possible in complex scenarios.

**EDIT**
I've updated the `assets` and `watch` tasks too in order to call the callback function on end. 
The task's signature was misleading (there was a callback parameter not used in code) and I spent some time figuring out why my callback wasn't called...
