### PR TITLE
Support for dimmer with zero opacity

### DIFF
--- a/src/definitions/modules/dimmer.js
+++ b/src/definitions/modules/dimmer.js
@@ -385,7 +385,7 @@ $.fn.dimmer = function(parameters) {
               colorArray = color.split(','),
               isRGBA     = (colorArray && colorArray.length == 4)
             ;
-            opacity    = settings.opacity || opacity;
+            opacity    = settings.opacity === 0 ? 0 : settings.opacity || opacity;
             if(isRGBA) {
               colorArray[3] = opacity + ')';
               color         = colorArray.join(',');


### PR DESCRIPTION
If the dimmer has a opacity setting of 0, the CSS background-color is set to `rgba(0, 0, 0, undefined)`, due to the way the opacity variable is set. This PR accounts for an opacity setting of 0.