### PR TITLE
Ability to cancel a modal hide from the onHide callback

### DIFF
--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -365,7 +365,10 @@ $.fn.modal = function(parameters) {
             : function(){}
           ;
           module.debug('Hiding modal');
-          settings.onHide.call(element);
+          if(settings.onHide.call(element, $(this)) === false) {
+            module.verbose('Hide callback returned false cancelling hide');
+            return;
+          }
 
           if( module.is.animating() || module.is.active() ) {
             if(settings.transition && $.fn.transition !== undefined && $module.transition('is supported')) {
@@ -854,7 +857,7 @@ $.fn.modal.settings = {
   onVisible  : function(){},
 
   // called before hide animation
-  onHide     : function(){},
+  onHide     : function(){ return true; },
 
   // called after hide animation
   onHidden   : function(){},


### PR DESCRIPTION
Currently the modal allows the user to cancel a hide from the `onDeny` and `onApprove` callbacks, but not from the `onHide`. This could be useful if you want to stop the user from hiding a modal but don't want to set `closable` to false.

For example, if you have a popup that submits a request to the server, and you want to display a loading state after the user has submitted, you could temporarily disable closing the popup by returning false from the `onHide` callback while the form submission is in progress.

Happy to also create a PR for the docs repository documenting this change.