### PR TITLE
Fix for IE/Firefox bug with vertical divider in stackable grid

### DIFF
--- a/src/definitions/collections/grid.less
+++ b/src/definitions/collections/grid.less
@@ -142,6 +142,11 @@
 .ui.grid .column + .ui.vertical.divider {
   height: ~"calc(50% - "(@rowSpacing/2)~")";
 }
+@media only screen and (max-width: @largestMobileScreen) {
+  .ui.stackable.grid .column + .ui.vertical.divider {
+    height: auto;
+  }
+}
 
 /* Remove Border on Last Horizontal Segment */
 .ui.grid > .row > .column:last-child > .horizontal.segment,


### PR DESCRIPTION
A `vertical divider` in a `grid` has a `height: calc(50% - 1rem );` applied (see https://github.com/Semantic-Org/Semantic-UI/blob/6bce4fc05d1ed5cec6857fb913d4205bcfc3f15a/src/definitions/collections/grid.less#L143). When the grid is `stackable` and resized to mobile widths in IE/Firefox, this causes the (now horizontal) divider to have a large height. This only occurs if the columns and divider are within a `row` div (possibly due to the `flex` style of the `row` class).

This PR adds another style that resets back to `height: auto;`.

The alternative is to add a more specific selector to `divider.less` for the mobile `stackable grid` (on line https://github.com/Semantic-Org/Semantic-UI/blob/4ce3085fc4be6770ff270096edc1f09d01bc8016/src/definitions/elements/divider.less#L138). Adding a `.ui.stackable.grid .column + .ui.vertical.divider` selector will cause this style to be applied after the height above, overriding it with `auto`. Happy change the commits in this PR if this is preferable.

**EDIT** Bug also occurs in Firefox, edited description and title to match.