### PR TITLE
Make checkbox labels cursors always look consistent

### DIFF
--- a/src/definitions/modules/checkbox.less
+++ b/src/definitions/modules/checkbox.less
@@ -63,7 +63,7 @@
 
 .ui.checkbox .box,
 .ui.checkbox label {
-  cursor: auto;
+  cursor: pointer;
   position: relative;
   display: block;
   padding-left: @labelDistance;
@@ -231,7 +231,8 @@
 ---------------*/
 
 .ui.read-only.checkbox,
-.ui.read-only.checkbox label {
+.ui.read-only.checkbox label,
+.ui.checkbox input[readonly] + label {
   cursor: default;
 }
 
@@ -261,7 +262,6 @@
 
 /* Selectable Label */
 .ui.checkbox input.hidden + label {
-  cursor: pointer;
   user-select: none;
 }
 


### PR DESCRIPTION
While doing usability tests in an app that is using Semantic-Ui, some users got confused by the lack of consistency of the checkbox label's cursors. When the javascript module is in use, the pointer cursor is always used. When it isn't, the cursor is text or default, depending on the checkbox state.

With this PR, I made it consistent in every scenario (with or without the javascript module):
- When the checkbox is active, the pointer cursor will be used
- When the checkbox is disabled or read-only, the default cursor will be used

Here is a fiddle that shows how the labels are currently inconsistent: http://jsfiddle.net/davialexandre/w24cehL6/
