### PR TITLE
fix menu dropdown width problem #3117

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -224,7 +224,6 @@
 /* Menu */
 .ui.menu .dropdown.item .menu {
   left: 0px;
-  min-width: ~"calc(100% - 1px)";
   border-radius: 0em 0em @dropdownMenuBorderRadius @dropdownMenuBorderRadius;
   background: @dropdownBackground;
   margin: @dropdownMenuDistance 0px 0px;


### PR DESCRIPTION
The fix removes the min-width property of the dropdown making it always adapt itself to content's width. Maybe this isn't the expected behavior - I can't figure out why min-width is affecting the width when content exceeds parent's width.
