### PR TITLE
Fix for flags with invalid country class

### DIFF
--- a/src/definitions/elements/flag.less
+++ b/src/definitions/elements/flag.less
@@ -45,7 +45,7 @@ i.flag:not(.icon) {
 i.flag:not(.icon):before {
   display: inline-block;
   content: '';
-  background: url(@spritePath) no-repeat 0px 0px;
+  background: url(@spritePath) no-repeat -108px -1976px;
   width: @width;
   height: @height;
 }


### PR DESCRIPTION
Fix for #3260. When a flag has a missing or invalid country class name, render blank instead of showing the flag of Andorra.