### PR TITLE
[Flag] Adding Scotland and Wales

### DIFF
--- a/src/themes/default/elements/flag.overrides
+++ b/src/themes/default/elements/flag.overrides
@@ -766,6 +766,10 @@ i.flag.sc:before,
 i.flag.seychelles:before {
   background-position: -72px -988px;
 }
+i.flag.gb.sct:before,
+i.flag.scotland:before {
+  background-position: -72px -1014px;
+}
 i.flag.sd:before,
 i.flag.sudan:before {
   background-position: -72px -1040px;
@@ -947,6 +951,10 @@ i.flag.vietnam:before {
 i.flag.vu:before,
 i.flag.vanuatu:before {
   background-position: -108px -182px;
+}
+i.flag.gb.wls:before,
+i.flag.walles:before {
+  background-position: -108px -208px;
 }
 i.flag.wf:before,
 i.flag.wallis.and.futuna:before {

--- a/src/themes/default/elements/flag.overrides
+++ b/src/themes/default/elements/flag.overrides
@@ -953,7 +953,7 @@ i.flag.vanuatu:before {
   background-position: -108px -182px;
 }
 i.flag.gb.wls:before,
-i.flag.walles:before {
+i.flag.wales:before {
   background-position: -108px -208px;
 }
 i.flag.wf:before,


### PR DESCRIPTION
Scotland and Wales flags are available in the sprite, but do not exist in the CSS. Added them in this PR. Their ISO code is "GB-SCT", and "GB-WLS", respectively, as described in https://en.wikipedia.org/wiki/ISO_3166-2:GB