### PR TITLE
Fix for search selection dropdown

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -229,15 +229,6 @@ $.fn.dropdown = function(parameters) {
         },
 
         select: {
-          firstUnfiltered: function() {
-            module.verbose('Selecting first non-filtered element');
-            module.remove.selectedItem();
-            $item
-              .not(selector.unselectable)
-                .eq(0)
-                .addClass(className.selected)
-            ;
-          },
           nextAvailable: function($selected) {
             $selected = $selected.eq(0);
             var
@@ -606,7 +597,6 @@ $.fn.dropdown = function(parameters) {
               if(module.is.multiple()) {
                 module.filterActive();
               }
-              module.select.firstUnfiltered();
               if( module.has.allResultsFiltered() ) {
                 if( settings.onNoResults.call(element, searchTerm) ) {
                   if(!settings.allowAdditions) {


### PR DESCRIPTION
When using search selection dropdown, the `selected` class is removed from the actual selected item and is placed on the first item of the list. Removed filter code from removing and selecting the first item in the list.
