### PR TITLE
Update `gulp-autoprefixer`

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "del": "^1.2.0",
     "extend": "^2.0.1",
     "gulp": "^3.9.0",
-    "gulp-autoprefixer": "^2.3.1",
+    "gulp-autoprefixer": "^3.0.0",
     "gulp-chmod": "^1.2.0",
     "gulp-clone": "^1.0.0",
     "gulp-concat": "^2.6.0",


### PR DESCRIPTION
The current version (`2.3.1`) of `gulp-autoprefixer` is pointing to the deprecated [`autoprefixer-core`](https://github.com/ai/autoprefixer-core). Latest version (`gulp-autoprefixer@3.0.0`) is OK.