### PR TITLE
Add a style option

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,5 +61,6 @@
     "gulp-git": "*",
     "gulp-tap": "*",
     "merge-stream": "*"
-  }
+  },
+  "style": "dist/semantic.css"
 }


### PR DESCRIPTION
It allows some tools like `npm-css` and `postcss` to import styles from the node_modules directory. It's awesome to write just `@import "semantic-ui"` to load css.