### PR TITLE
[Checkbox] Fixed arrow keys in radio button group

### DIFF
--- a/src/definitions/modules/checkbox.js
+++ b/src/definitions/modules/checkbox.js
@@ -187,7 +187,11 @@ $.fn.checkbox = function(parameters) {
               keyCode = {
                 enter  : 13,
                 space  : 32,
-                escape : 27
+                escape : 27,
+                left   : 37,
+                up     : 38,
+                right  : 39,
+                down   : 40
               }
             ;
             if(key == keyCode.escape) {
@@ -198,6 +202,18 @@ $.fn.checkbox = function(parameters) {
             else if(!event.ctrlKey && ( key == keyCode.space || key == keyCode.enter) ) {
               module.verbose('Enter/space key pressed, toggling checkbox');
               module.toggle();
+              shortcutPressed = true;
+            }
+            else if(module.is.radio() && ( key == keyCode.left || key == keyCode.up || key == keyCode.right || key == keyCode.down) ) {
+              var delta = key == keyCode.left || key == keyCode.up ? -1 : 1;
+              var radios = module.get.radios();
+              if(radios.length > 1) {
+                var checkIndex = (radios.index($module) + delta + radios.length) % radios.length;
+                var checkModule = $(radios[checkIndex]).data(moduleNamespace);
+                if(checkModule) {
+                  checkModule.check();
+                }
+              }
               shortcutPressed = true;
             }
             else {


### PR DESCRIPTION
When using arrow keys inside a radio button group (such as the example in the docs at http://semantic-ui.com/modules/checkbox.html), the arrow keys cause the checked radio to change but the checkbox modules behind those radios don't monitor this change. This means that the `checked` class remains on the previously checked radio, and the `onChange` callback doesn't fire, leaving the checkbox module out of sync with the checked state of the radio input elements.

This PR fixes this bug by listening for arrow key keydown events, and calling `check` on the newly checked checkbox module.
