### PR TITLE
Fixes left arrow key in dropdown search input

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1184,20 +1184,21 @@ $.fn.dropdown = function(parameters) {
 
                 // left arrow (hide sub-menu)
                 if(pressedKey == keys.leftArrow) {
-
-                  isSubMenuItem = ($parentMenu[0] !== $menu[0]);
-
-                  if(isSubMenuItem) {
-                    module.verbose('Left key pressed, closing sub-menu');
-                    module.animate.hide(false,  $parentMenu);
-                    $selectedItem
-                      .removeClass(className.selected)
-                    ;
-                    $parentMenu
-                      .closest(selector.item)
-                        .addClass(className.selected)
-                    ;
-                    event.preventDefault();
+                  if(hasSelectedItem) {
+                    isSubMenuItem = ($parentMenu[0] !== $menu[0]);
+      
+                    if(isSubMenuItem) {
+                      module.verbose('Left key pressed, closing sub-menu');
+                      module.animate.hide(false,  $parentMenu);
+                      $selectedItem
+                        .removeClass(className.selected)
+                      ;
+                      $parentMenu
+                        .closest(selector.item)
+                          .addClass(className.selected)
+                      ;
+                      event.preventDefault();
+                    }  
                   }
                 }
 


### PR DESCRIPTION
For the case where no item is selected. Because in this case $parentMenu is still something else than $menu.