### PR TITLE
Add an automatic reinstallation process based on semantic.json

### DIFF
--- a/tasks/config/project/install.js
+++ b/tasks/config/project/install.js
@@ -416,7 +416,7 @@ module.exports = {
           {
             name: 'Yes',
             value: true
-          },
+          }
         ]
       },
       {
@@ -730,7 +730,7 @@ module.exports = {
 
     /* Rename Files */
     rename: {
-      json : { extname : '.json' },
+      json : { extname : '.json' }
     },
 
     /* Copy Install Folders */
@@ -750,6 +750,17 @@ module.exports = {
         preserveFiles     : true
       }
 
+    }
+  },
+
+  // Detect whether there is a semantic.json configuration and that the auto-install option is set to True
+  // Returns the semantic.json configuration
+  autoInstall: function() {
+    var config = when.hasConfig();
+    if (config && config['auto-install']) {
+      return when.hasConfig();
+    } else {
+      return false;
     }
   }
 

--- a/tasks/install.js
+++ b/tasks/install.js
@@ -191,14 +191,17 @@ if(manager.name == 'NPM') {
 
 gulp.task('run setup', function() {
 
-  return gulp
-    .src('gulpfile.js')
-    .pipe(prompt.prompt(questions.setup, function(setupAnswers) {
-      // hoist
-      answers = setupAnswers;
-    }))
-  ;
-
+  // If auto-install is switched on, we skip the configuration section and simply reuse the configuration from semantic.json
+  if (install.autoInstall()) {
+    answers = install.autoInstall();
+  } else {
+    return gulp
+        .src('gulpfile.js')
+        .pipe(prompt.prompt(questions.setup, function(setupAnswers) {
+          // hoist
+          answers = setupAnswers;
+        }));
+  }
 });
 
 gulp.task('create install files', function(callback) {
@@ -414,17 +417,23 @@ gulp.task('clean up install', function() {
     console.log('');
   }
 
-  return gulp
-    .src('gulpfile.js')
-    .pipe(prompt.prompt(questions.cleanup, function(answers) {
-      if(answers.cleanup == 'yes') {
-        del(install.setupFiles);
-      }
-      if(answers.build == 'yes') {
-        gulp.start('build');
-      }
-    }))
-  ;
+  // If auto-install is switched on, we skip the configuration section and simply build the dependencies
+  if (install.autoInstall()) {
+    return gulp.start('build');
+  } else {
+    return gulp
+        .src('gulpfile.js')
+        .pipe(prompt.prompt(questions.cleanup, function(answers) {
+          if(answers.cleanup == 'yes') {
+            del(install.setupFiles);
+          }
+          if(answers.build == 'yes') {
+            gulp.start('build');
+          }
+        }));
+  }
+
+
 });
 
 runSequence(


### PR DESCRIPTION
This feature is added to allow to automatize a semantic-ui
re-installation with the same configuration (such as in your CI build)

To switch it on, simply add ("auto-install": true) in semantic.json

Of course, configuration name could be changed :) 