### PR TITLE
extend modal 'closable' option #262

### DIFF
--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -264,12 +264,12 @@ $.fn.modal = function(parameters) {
               escapeKey = 27
             ;
             if(keyCode == escapeKey) {
-              if(settings.closable) {
+              if(settings.closable && settings.closable !== 'click') {
                 module.debug('Escape key pressed hiding modal');
                 module.hide();
               }
               else {
-                module.debug('Escape key pressed, but closable is set to false');
+                module.debug('Escape key pressed, but closable is set to ' + settings.closable);
               }
               event.preventDefault();
             }
@@ -494,7 +494,7 @@ $.fn.modal = function(parameters) {
             $module.removeClass(className.active);
           },
           clickaway: function() {
-            if(settings.closable) {
+            if(settings.closable && settings.closable !== 'escapeKey') {
               $dimmer
                 .off('click' + elementNamespace)
               ;
@@ -579,7 +579,7 @@ $.fn.modal = function(parameters) {
             }
           },
           clickaway: function() {
-            if(settings.closable) {
+            if(settings.closable && settings.closable !== 'escapeKey') {
               $dimmer
                 .on('click' + elementNamespace, module.event.click)
               ;


### PR DESCRIPTION
to specify the exact closable behavior of a modal you can now set closable to `click` to allow closing only by clicking on the dimmer or you can set it to `escapeKey` to allow closing only by pressing the escape key.
