### PR TITLE
[API] onResponse was not obeying return dataType

### DIFF
--- a/src/definitions/behaviors/api.js
+++ b/src/definitions/behaviors/api.js
@@ -469,7 +469,7 @@ $.api = $.fn.api = function(parameters) {
                 elapsedTime        = (new Date().getTime() - requestStartTime),
                 timeLeft           = (settings.loadingDuration - elapsedTime),
                 translatedResponse = ( $.isFunction(settings.onResponse) )
-                  ? settings.onResponse.call(context, $.extend(true, {}, response))
+                  ? settings.onResponse.call(context, (settings.onResponseSendPlainText ? response : $.extend(true, {}, response) ) )
                   : false
               ;
               timeLeft = (timeLeft > 0)
@@ -1079,6 +1079,9 @@ $.api.settings = {
 
   // after request
   onResponse  : false, // function(response) { },
+
+  // send onResponse callback the plain text of the response rather than a hash
+  onResponseSendPlainText : false,
 
   // response was successful, if JSON passed validation
   onSuccess   : function(response, $module) {},


### PR DESCRIPTION
I'm new to Semantic and trying to get brain around a few concepts. Thank you for this awesome work.

I am exploring using Semantic with a legacy backend. The legacy backend returns JSON that requires processing. One key in the returned JSON is 'html' from which, say a tab's HTML contents, would be pulled.

Though my question applies to all API calls, running with tabs is a useful case study. A tab is hardwired to seek and get returned from server plain HTML. My objective would be to leverage as much Semantic tab logic as possible but get it to work with this legacy JSON backend.

This discussion regarding a related topic discusses the use of 'mockResponseAsync' for a related purpose:
https://github.com/Semantic-Org/Semantic-UI/issues/1736

It seems onResponse is the simpler solution. I was glad to find it. But I did not understand why the response text was being transformed into a hash before being sent to the 'onResponse' callback. The first thing I need to do on the other end is reassemble the *original* response text so I can process it in proprietary fashion. Maybe there's a reason for this transformation?

My suggestion retains the default and offers a flag to skip this wasteful transformation so it needn't happen every server hit if it is not necessary.

Maybe I misunderstood 'mockResponseAsync' and that's where I should be working? If not, maybe the default behavior for 'onResponse' transforming the text might be confusing to others as well.

Thanks for the awesome work. I look forward to getting deeper. Even without this change, it's cool that hooks are in place so I can wire Semantic into a legacy app.