### PR TITLE
[Dropdown] - Placeholder text is lost after dropdown refresh

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -389,7 +389,6 @@ $.fn.dropdown = function(parameters) {
           $module
             .removeData(metadata.defaultText)
             .removeData(metadata.defaultValue)
-            .removeData(metadata.placeholderText)
           ;
         },
 


### PR DESCRIPTION
Remove the line that removes the placeholder text fixes the bug.
