### PR TITLE
Fixes #3761 issue with misspelled callbacks

### DIFF
--- a/src/definitions/modules/checkbox.js
+++ b/src/definitions/modules/checkbox.js
@@ -268,7 +268,7 @@ $.fn.checkbox = function(parameters) {
           }
           module.debug('Enabling checkbox');
           module.set.enabled();
-          settings.onEnabled.call(input);
+          settings.onEnable.call(input);
         },
 
         disable: function() {
@@ -278,7 +278,7 @@ $.fn.checkbox = function(parameters) {
           }
           module.debug('Disabling checkbox');
           module.set.disabled();
-          settings.onDisabled.call(input);
+          settings.onDisable.call(input);
         },
 
         get: {


### PR DESCRIPTION
This is a possible fix for #3761 but I don't know about the possible backwards compatibility issues. I do not think is prudent to have both versions of the callback in the enable/disable methods.