### PR TITLE
Fixes #3794 - Dropdown issues a burst of requests for first autocomplete word

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -680,9 +680,12 @@ $.fn.dropdown = function(parameters) {
               }
             }
           ;
-          if( !$module.api('get request') ) {
+
+          var apiNamespace = settings.apiSettings && settings.apiSettings.namespace || $.api.settings.namespace;
+          if(!$module.data('module-' + apiNamespace)) {
             module.setup.api();
           }
+
           apiSettings = $.extend(true, {}, apiSettings, settings.apiSettings);
           $module
             .api('setting', apiSettings)


### PR DESCRIPTION
Fixes #3794. 

The test whether the API has been set up always fails if throttle parameter is greater than `0`. The `get request` behaviour returns false because due to throttling no request has been created. 

My proposed test for the presence of an initialised API solves this.