### PR TITLE
Fix .disabled.reveal

### DIFF
--- a/src/definitions/elements/reveal.less
+++ b/src/definitions/elements/reveal.less
@@ -219,17 +219,7 @@
               States
 *******************************/
 
-.ui.disabled.reveal:hover > .hidden.hidden.content {
-  position: static !important;
-  display: block !important;
-  opacity: 1 !important;
-  top: 0 !important;
-  left: 0 !important;
-  right: auto !important;
-  bottom: auto !important;
-  transform: none !important;
-}
-.ui.disabled.reveal:hover > .visible.visible.content {
+.ui.disabled.reveal:hover > .visible.content {
   display: none !important;
 }
 

--- a/src/definitions/elements/reveal.less
+++ b/src/definitions/elements/reveal.less
@@ -219,7 +219,7 @@
               States
 *******************************/
 
-.ui.disabled.reveal:hover > .visible.visible.content {
+.ui.disabled.reveal:hover > .hidden.hidden.content {
   position: static !important;
   display: block !important;
   opacity: 1 !important;
@@ -229,7 +229,7 @@
   bottom: auto !important;
   transform: none !important;
 }
-.ui.disabled.reveal:hover > .hidden.hidden.content {
+.ui.disabled.reveal:hover > .visible.visible.content {
   display: none !important;
 }
 


### PR DESCRIPTION
As the [document](http://semantic-ui.com/elements/reveal.html#disabled) says:
>  A disabled reveal will not animate when hovered

Maybe the css selector in reveal.less is wrong.