### PR TITLE
Fix image not centered in Item View on Mobile in IE11 #2994

### DIFF
--- a/src/definitions/views/item.less
+++ b/src/definitions/views/item.less
@@ -358,13 +358,11 @@
     flex-direction: column;
     margin: @mobileItemSpacing 0em;
   }
-  .ui.items > .item > .image {
+  .ui.items > .item > .image,
+  .ui.items > .item > .image > img {
     display: block;
     margin-left: auto;
     margin-right: auto;
-  }
-  .ui.items > .item > .image,
-  .ui.items > .item > .image > img {
     max-width: 100% !important;
     width: @mobileImageWidth !important;
     max-height: @mobileImageMaxHeight !important;


### PR DESCRIPTION
Now image is centered. But in IE width of Item element more than width of the window.

![image](https://cloud.githubusercontent.com/assets/1799798/13723255/2d954f62-e870-11e5-818a-dbe7a51b81d8.png)
