### PR TITLE
Bake 'easeOutQuad' easing function into nag module.

### DIFF
--- a/src/definitions/modules/nag.js
+++ b/src/definitions/modules/nag.js
@@ -483,4 +483,11 @@ $.fn.nag.settings = {
 
 };
 
+// Adds easing
+$.extend( $.easing, {
+  easeOutQuad: function (x, t, b, c, d) {
+    return -c *(t/=d)*(t-2) + b;
+  }
+});
+
 })( jQuery, window, document );


### PR DESCRIPTION
https://github.com/Semantic-Org/Semantic-UI/issues/211#issuecomment-106290794

As mentioned above the nag module is missing the easing function to work properly. The normal jquery library only supports 'swing' and 'linear' easing functions. The added code is a copy from here: 

https://github.com/Semantic-Org/Semantic-UI/blob/master/src/definitions/modules/accordion.js#L589-L593

Please merge and make people happy :tada: 