### PR TITLE
Cards improvement: add cards count per device/screen

### DIFF
--- a/src/definitions/views/card.less
+++ b/src/definitions/views/card.less
@@ -834,6 +834,528 @@ a.ui.card:hover,
   margin-right: @tenCardSpacing;
 }
 
+/*--------------
+   Card Count per device
+---------------*/
+
+/* Mobily Only */
+@media only screen and (max-width : @largestMobileScreen) {
+  .ui[class*="one mobile cards"] {
+    margin-left: @oneCardOffset !important;
+    margin-right: @oneCardOffset !important;
+  }
+  .ui[class*="one mobile cards"] > .card {
+    width: @oneCard !important;
+  }
+
+  .ui[class*="two mobile cards"] {
+    margin-left: @twoCardOffset !important;
+    margin-right: @twoCardOffset !important;
+  }
+  .ui[class*="two mobile cards"] > .card {
+    width: @twoCard !important;
+    margin-left: @twoCardSpacing !important;
+    margin-right: @twoCardSpacing !important;
+  }
+
+  .ui[class*="three mobile cards"] {
+    margin-left: @threeCardOffset !important;
+    margin-right: @threeCardOffset !important;
+  }
+  .ui[class*="three mobile cards"] > .card {
+    width: @threeCard !important;
+    margin-left: @threeCardSpacing !important;
+    margin-right: @threeCardSpacing !important;
+  }
+
+  .ui[class*="four mobile cards"]{
+    margin-left: @fourCardOffset !important;
+    margin-right: @fourCardOffset !important;
+  }
+  .ui[class*="four mobile cards"] > .card {
+    width: @fourCard !important;
+    margin-left: @fourCardSpacing !important;
+    margin-right: @fourCardSpacing !important;
+  }
+
+  .ui[class*="five mobile cards"] {
+    margin-left: @fiveCardOffset !important;
+    margin-right: @fiveCardOffset !important;
+  }
+  .ui[class*="five mobile cards"] > .card {
+    width: @fiveCard !important;
+    margin-left: @fiveCardSpacing !important;
+    margin-right: @fiveCardSpacing !important;
+  }
+
+  .ui[class*="six mobile cards"] {
+    margin-left: @sixCardOffset !important;
+    margin-right: @sixCardOffset !important;
+  }
+  .ui[class*="six mobile cards"] > .card {
+    width: @sixCard !important;
+    margin-left: @sixCardSpacing !important;
+    margin-right: @sixCardSpacing !important;
+  }
+
+  .ui[class*="seven mobile cards"] {
+    margin-left: @sevenCardOffset !important;
+    margin-right: @sevenCardOffset !important;
+  }
+  .ui[class*="seven mobile cards"] > .card {
+    width: @sevenCard !important;
+    margin-left: @sevenCardSpacing !important;
+    margin-right: @sevenCardSpacing !important;
+  }
+
+  .ui[class*="eight mobile cards"] {
+    margin-left: @eightCardOffset !important;
+    margin-right: @eightCardOffset !important;
+  }
+  .ui[class*="eight mobile cards"] > .card {
+    width: @eightCard !important;
+    margin-left: @eightCardSpacing !important;
+    margin-right: @eightCardSpacing !important;
+    font-size: 11px !important;
+  }
+
+  .ui[class*="nine mobile cards"] {
+    margin-left: @nineCardOffset !important;
+    margin-right: @nineCardOffset !important;
+  }
+  .ui[class*="nine mobile cards"] > .card {
+    width: @nineCard !important;
+    margin-left: @nineCardSpacing !important;
+    margin-right: @nineCardSpacing !important;
+    font-size: 10px !important;
+  }
+
+  .ui[class*="ten mobile cards"] {
+    margin-left: @tenCardOffset !important;
+    margin-right: @tenCardOffset !important;
+  }
+  .ui[class*="ten mobile cards"] > .card {
+    width: @tenCard !important;
+    margin-left: @tenCardSpacing !important;
+    margin-right: @tenCardSpacing !important;
+  }
+}
+
+/* Tablet Only */
+
+@media only screen and (min-width: 768px) and (max-width: 991px) {
+  .ui[class*="one tablet cards"] {
+    margin-left: @oneCardOffset !important;
+    margin-right: @oneCardOffset !important;
+  }
+  .ui[class*="one tablet cards"] > .card {
+    width: @oneCard !important;
+  }
+
+  .ui[class*="two tablet cards"] {
+    margin-left: @twoCardOffset !important;
+    margin-right: @twoCardOffset !important;
+  }
+  .ui[class*="two tablet cards"] > .card {
+    width: @twoCard !important;
+    margin-left: @twoCardSpacing !important;
+    margin-right: @twoCardSpacing !important;
+  }
+
+  .ui[class*="three tablet cards"] {
+    margin-left: @threeCardOffset !important;
+    margin-right: @threeCardOffset !important;
+  }
+  .ui[class*="three tablet cards"] > .card {
+    width: @threeCard !important;
+    margin-left: @threeCardSpacing !important;
+    margin-right: @threeCardSpacing !important;
+  }
+
+  .ui[class*="four tablet cards"]{
+    margin-left: @fourCardOffset !important;
+    margin-right: @fourCardOffset !important;
+  }
+  .ui[class*="four tablet cards"] > .card {
+    width: @fourCard !important;
+    margin-left: @fourCardSpacing !important;
+    margin-right: @fourCardSpacing !important;
+  }
+
+  .ui[class*="five tablet cards"] {
+    margin-left: @fiveCardOffset !important;
+    margin-right: @fiveCardOffset !important;
+  }
+  .ui[class*="five tablet cards"] > .card {
+    width: @fiveCard !important;
+    margin-left: @fiveCardSpacing !important;
+    margin-right: @fiveCardSpacing !important;
+  }
+
+  .ui[class*="six tablet cards"] {
+    margin-left: @sixCardOffset !important;
+    margin-right: @sixCardOffset !important;
+  }
+  .ui[class*="six tablet cards"] > .card {
+    width: @sixCard !important;
+    margin-left: @sixCardSpacing !important;
+    margin-right: @sixCardSpacing !important;
+  }
+
+  .ui[class*="seven tablet cards"] {
+    margin-left: @sevenCardOffset !important;
+    margin-right: @sevenCardOffset !important;
+  }
+  .ui[class*="seven tablet cards"] > .card {
+    width: @sevenCard !important;
+    margin-left: @sevenCardSpacing !important;
+    margin-right: @sevenCardSpacing !important;
+  }
+
+  .ui[class*="eight tablet cards"] {
+    margin-left: @eightCardOffset !important;
+    margin-right: @eightCardOffset !important;
+  }
+  .ui[class*="eight tablet cards"] > .card {
+    width: @eightCard !important;
+    margin-left: @eightCardSpacing !important;
+    margin-right: @eightCardSpacing !important;
+    font-size: 11px !important;
+  }
+
+  .ui[class*="nine tablet cards"] {
+    margin-left: @nineCardOffset !important;
+    margin-right: @nineCardOffset !important;
+  }
+  .ui[class*="nine tablet cards"] > .card {
+    width: @nineCard !important;
+    margin-left: @nineCardSpacing !important;
+    margin-right: @nineCardSpacing !important;
+    font-size: 10px !important;
+  }
+
+  .ui[class*="ten tablet cards"] {
+    margin-left: @tenCardOffset !important;
+    margin-right: @tenCardOffset !important;
+  }
+  .ui[class*="ten tablet cards"] > .card {
+    width: @tenCard !important;
+    margin-left: @tenCardSpacing !important;
+    margin-right: @tenCardSpacing !important;
+  }
+}
+
+/* Small Monitor */
+
+@media only screen and (min-width: 992px) {
+  .ui[class*="one wide computer cards"] {
+    margin-left: @oneCardOffset !important;
+    margin-right: @oneCardOffset !important;
+  }
+  .ui[class*="one wide computer cards"] > .card {
+    width: @oneCard !important;
+  }
+
+  .ui[class*="two wide computer cards"] {
+    margin-left: @twoCardOffset !important;
+    margin-right: @twoCardOffset !important;
+  }
+  .ui[class*="two wide computer cards"] > .card {
+    width: @twoCard !important;
+    margin-left: @twoCardSpacing !important;
+    margin-right: @twoCardSpacing !important;
+  }
+
+  .ui[class*="three wide computer cards"] {
+    margin-left: @threeCardOffset !important;
+    margin-right: @threeCardOffset !important;
+  }
+  .ui[class*="three wide computer cards"] > .card {
+    width: @threeCard !important;
+    margin-left: @threeCardSpacing !important;
+    margin-right: @threeCardSpacing !important;
+  }
+
+  .ui[class*="four wide computer cards"]{
+    margin-left: @fourCardOffset !important;
+    margin-right: @fourCardOffset !important;
+  }
+  .ui[class*="four wide computer cards"] > .card {
+    width: @fourCard !important;
+    margin-left: @fourCardSpacing !important;
+    margin-right: @fourCardSpacing !important;
+  }
+
+  .ui[class*="five wide computer cards"] {
+    margin-left: @fiveCardOffset !important;
+    margin-right: @fiveCardOffset !important;
+  }
+  .ui[class*="five wide computer cards"] > .card {
+    width: @fiveCard !important;
+    margin-left: @fiveCardSpacing !important;
+    margin-right: @fiveCardSpacing !important;
+  }
+
+  .ui[class*="six wide computer cards"] {
+    margin-left: @sixCardOffset !important;
+    margin-right: @sixCardOffset !important;
+  }
+  .ui[class*="six wide computer cards"] > .card {
+    width: @sixCard !important;
+    margin-left: @sixCardSpacing !important;
+    margin-right: @sixCardSpacing !important;
+  }
+
+  .ui[class*="seven wide computer cards"] {
+    margin-left: @sevenCardOffset !important;
+    margin-right: @sevenCardOffset !important;
+  }
+  .ui[class*="seven wide computer cards"] > .card {
+    width: @sevenCard !important;
+    margin-left: @sevenCardSpacing !important;
+    margin-right: @sevenCardSpacing !important;
+  }
+
+  .ui[class*="eight wide computer cards"] {
+    margin-left: @eightCardOffset !important;
+    margin-right: @eightCardOffset !important;
+  }
+  .ui[class*="eight wide computer cards"] > .card {
+    width: @eightCard !important;
+    margin-left: @eightCardSpacing !important;
+    margin-right: @eightCardSpacing !important;
+    font-size: 11px !important;
+  }
+
+  .ui[class*="nine wide computer cards"] {
+    margin-left: @nineCardOffset !important;
+    margin-right: @nineCardOffset !important;
+  }
+  .ui[class*="nine wide computer cards"] > .card {
+    width: @nineCard !important;
+    margin-left: @nineCardSpacing !important;
+    margin-right: @nineCardSpacing !important;
+    font-size: 10px !important;
+  }
+
+  .ui[class*="ten wide computer cards"] {
+    margin-left: @tenCardOffset !important;
+    margin-right: @tenCardOffset !important;
+  }
+  .ui[class*="ten wide computer cards"] > .card {
+    width: @tenCard !important;
+    margin-left: @tenCardSpacing !important;
+    margin-right: @tenCardSpacing !important;
+  }
+}
+
+/* Large Monitor */
+
+@media only screen and (min-width: 1200px) {
+  .ui[class*="one wide large screen cards"] {
+    margin-left: @oneCardOffset !important;
+    margin-right: @oneCardOffset !important;
+  }
+  .ui[class*="one wide large screen cards"] > .card {
+    width: @oneCard !important;
+  }
+
+  .ui[class*="two wide large screen cards"] {
+    margin-left: @twoCardOffset !important;
+    margin-right: @twoCardOffset !important;
+  }
+  .ui[class*="two wide large screen cards"] > .card {
+    width: @twoCard !important;
+    margin-left: @twoCardSpacing !important;
+    margin-right: @twoCardSpacing !important;
+  }
+
+  .ui[class*="three wide large screen cards"] {
+    margin-left: @threeCardOffset !important;
+    margin-right: @threeCardOffset !important;
+  }
+  .ui[class*="three wide large screen cards"] > .card {
+    width: @threeCard !important;
+    margin-left: @threeCardSpacing !important;
+    margin-right: @threeCardSpacing !important;
+  }
+
+  .ui[class*="four wide large screen cards"]{
+    margin-left: @fourCardOffset !important;
+    margin-right: @fourCardOffset !important;
+  }
+  .ui[class*="four wide large screen cards"] > .card {
+    width: @fourCard !important;
+    margin-left: @fourCardSpacing !important;
+    margin-right: @fourCardSpacing !important;
+  }
+
+  .ui[class*="five wide large screen cards"] {
+    margin-left: @fiveCardOffset !important;
+    margin-right: @fiveCardOffset !important;
+  }
+  .ui[class*="five wide large screen cards"] > .card {
+    width: @fiveCard !important;
+    margin-left: @fiveCardSpacing !important;
+    margin-right: @fiveCardSpacing !important;
+  }
+
+  .ui[class*="six wide large screen cards"] {
+    margin-left: @sixCardOffset !important;
+    margin-right: @sixCardOffset !important;
+  }
+  .ui[class*="six wide large screen cards"] > .card {
+    width: @sixCard !important;
+    margin-left: @sixCardSpacing !important;
+    margin-right: @sixCardSpacing !important;
+  }
+
+  .ui[class*="seven wide large screen cards"] {
+    margin-left: @sevenCardOffset !important;
+    margin-right: @sevenCardOffset !important;
+  }
+  .ui[class*="seven wide large screen cards"] > .card {
+    width: @sevenCard !important;
+    margin-left: @sevenCardSpacing !important;
+    margin-right: @sevenCardSpacing !important;
+  }
+
+  .ui[class*="eight wide large screen cards"] {
+    margin-left: @eightCardOffset !important;
+    margin-right: @eightCardOffset !important;
+  }
+  .ui[class*="eight wide large screen cards"] > .card {
+    width: @eightCard !important;
+    margin-left: @eightCardSpacing !important;
+    margin-right: @eightCardSpacing !important;
+    font-size: 11px !important;
+  }
+
+  .ui[class*="nine wide large screen cards"] {
+    margin-left: @nineCardOffset !important;
+    margin-right: @nineCardOffset !important;
+  }
+  .ui[class*="nine wide large screen cards"] > .card {
+    width: @nineCard !important;
+    margin-left: @nineCardSpacing !important;
+    margin-right: @nineCardSpacing !important;
+    font-size: 10px !important;
+  }
+
+  .ui[class*="ten wide large screen cards"] {
+    margin-left: @tenCardOffset !important;
+    margin-right: @tenCardOffset !important;
+  }
+  .ui[class*="ten wide large screen cards"] > .card {
+    width: @tenCard !important;
+    margin-left: @tenCardSpacing !important;
+    margin-right: @tenCardSpacing !important;
+  }
+}
+
+/* Widescreen */
+
+@media only screen and (min-width: 1920px) {
+  .ui[class*="one wide widescreen cards"] {
+    margin-left: @oneCardOffset !important;
+    margin-right: @oneCardOffset !important;
+  }
+  .ui[class*="one wide widescreen cards"] > .card {
+    width: @oneCard !important;
+  }
+
+  .ui[class*="two wide widescreen cards"] {
+    margin-left: @twoCardOffset !important;
+    margin-right: @twoCardOffset !important;
+  }
+  .ui[class*="two wide widescreen cards"] > .card {
+    width: @twoCard !important;
+    margin-left: @twoCardSpacing !important;
+    margin-right: @twoCardSpacing !important;
+  }
+
+  .ui[class*="three wide widescreen cards"] {
+    margin-left: @threeCardOffset !important;
+    margin-right: @threeCardOffset !important;
+  }
+  .ui[class*="three wide widescreen cards"] > .card {
+    width: @threeCard !important;
+    margin-left: @threeCardSpacing !important;
+    margin-right: @threeCardSpacing !important;
+  }
+
+  .ui[class*="four wide widescreen cards"]{
+    margin-left: @fourCardOffset !important;
+    margin-right: @fourCardOffset !important;
+  }
+  .ui[class*="four wide widescreen cards"] > .card {
+    width: @fourCard !important;
+    margin-left: @fourCardSpacing !important;
+    margin-right: @fourCardSpacing !important;
+  }
+
+  .ui[class*="five wide widescreen cards"] {
+    margin-left: @fiveCardOffset !important;
+    margin-right: @fiveCardOffset !important;
+  }
+  .ui[class*="five wide widescreen cards"] > .card {
+    width: @fiveCard !important;
+    margin-left: @fiveCardSpacing !important;
+    margin-right: @fiveCardSpacing !important;
+  }
+
+  .ui[class*="six wide widescreen cards"] {
+    margin-left: @sixCardOffset !important;
+    margin-right: @sixCardOffset !important;
+  }
+  .ui[class*="six wide widescreen cards"] > .card {
+    width: @sixCard !important;
+    margin-left: @sixCardSpacing !important;
+    margin-right: @sixCardSpacing !important;
+  }
+
+  .ui[class*="seven wide widescreen cards"] {
+    margin-left: @sevenCardOffset !important;
+    margin-right: @sevenCardOffset !important;
+  }
+  .ui[class*="seven wide widescreen cards"] > .card {
+    width: @sevenCard !important;
+    margin-left: @sevenCardSpacing !important;
+    margin-right: @sevenCardSpacing !important;
+  }
+
+  .ui[class*="eight wide widescreen cards"] {
+    margin-left: @eightCardOffset !important;
+    margin-right: @eightCardOffset !important;
+  }
+  .ui[class*="eight wide widescreen cards"] > .card {
+    width: @eightCard !important;
+    margin-left: @eightCardSpacing !important;
+    margin-right: @eightCardSpacing !important;
+    font-size: 11px !important;
+  }
+
+  .ui[class*="nine wide widescreen cards"] {
+    margin-left: @nineCardOffset !important;
+    margin-right: @nineCardOffset !important;
+  }
+  .ui[class*="nine wide widescreen cards"] > .card {
+    width: @nineCard !important;
+    margin-left: @nineCardSpacing !important;
+    margin-right: @nineCardSpacing !important;
+    font-size: 10px !important;
+  }
+
+  .ui[class*="ten wide widescreen cards"] {
+    margin-left: @tenCardOffset !important;
+    margin-right: @tenCardOffset !important;
+  }
+  .ui[class*="ten wide widescreen cards"] > .card {
+    width: @tenCard !important;
+    margin-left: @tenCardSpacing !important;
+    margin-right: @tenCardSpacing !important;
+  }
+}
 
 /*-------------------
       Doubling


### PR DESCRIPTION
I added a way to set a different  amount of cards for each row per device/screen. Just like columns, but now for cards.

for example:
1 card per row for mobile
3 cards per row for tablet
4 cards per row for small screen
5 cards per row for large screen
6 cards per row for widescreen

`<div class="ui one mobile cards three tablet cards four wide computer cards five wide large screen cards six wide widescreen cards">`
