### PR TITLE
Set Internet Explorer support to 11+

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ Check out our [integration wiki](https://github.com/Semantic-Org/Semantic-UI/wik
 
 #### Browser Support
 
-* Last 2 Versions FF, Chrome, IE 10+, Safari Mac
-* IE 10+
+* Last 2 Versions FF, Chrome, Safari Mac
+* IE 11+
 * Android 4.4+, Chrome for Android 44+
 * iOS Safari 7+
 


### PR DESCRIPTION
Fields are using `pointer-events: none` when disabled with `<div class="disabled field">...</div>`, thus avoiding the children to be clicked. However, this CSS property isn't supported by Internet Explorer 10, [according to CanIUse](http://caniuse.com/#feat=pointer-events).