### PR TITLE
Support specifying sections in semantic.json to reduce output size

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.5.3",
     "gulp-rtlcss": "^0.1.4",
+    "gulp-tap": "^0.1.3",
     "gulp-uglify": "^1.2.0",
     "gulp-util": "^3.0.6",
     "gulp-watch": "^4.3.1",


### PR DESCRIPTION
The output CSS file, as described in issue #2381, seems to be way too large for many people.
This merge request adds a way to add specific sections to be taken from the sources in the `semantic.json` file. If the sections are not defined for a component then it will behave the old way, that is the whole component would be included.

Sections are case insensitive and interpreted as regular expressions.
They must be specified in the same order they appear in .less files.

Example of sections configuration for buttons:

```
  "sections": {
    "button": [
      "theme",
      "button",
      "states", "hover", "focus", "down", "active", "disabled",
      "types", "labeled button", "icon",
      "variations", "floated", "compact", "sizes", "icon only", "basic", "labeled icon", "fluid", "primary"
    ]
  }
```