### PR TITLE
Fix typo in placeholder styling for the Internet Explorer

### DIFF
--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -322,7 +322,7 @@
 .ui.form ::-webkit-input-placeholder {
   color: @inputPlaceholderColor;
 }
-.ui.form ::-ms-input-placeholder {
+.ui.form :-ms-input-placeholder {
   color: @inputPlaceholderColor;
 }
 .ui.form ::-moz-placeholder {
@@ -332,7 +332,7 @@
 .ui.form :focus::-webkit-input-placeholder {
   color: @inputPlaceholderFocusColor;
 }
-.ui.form :focus::-ms-input-placeholder {
+.ui.form :focus:-ms-input-placeholder {
   color: @inputPlaceholderFocusColor;
 }
 .ui.form :focus::-moz-placeholder {
@@ -343,7 +343,7 @@
 .ui.form .error ::-webkit-input-placeholder {
   color: @inputErrorPlaceholderColor;
 }
-.ui.form .error ::-ms-input-placeholder {
+.ui.form .error :-ms-input-placeholder {
   color: @inputErrorPlaceholderColor;
 }
 .ui.form .error ::-moz-placeholder {
@@ -353,7 +353,7 @@
 .ui.form .error :focus::-webkit-input-placeholder {
   color: @inputErrorPlaceholderFocusColor;
 }
-.ui.form .error :focus::-ms-input-placeholder {
+.ui.form .error :focus:-ms-input-placeholder {
   color: @inputErrorPlaceholderFocusColor;
 }
 .ui.form .error :focus::-moz-placeholder {

--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -344,7 +344,7 @@
   color: @inputErrorPlaceholderColor;
 }
 .ui.form .error :-ms-input-placeholder {
-  color: @inputErrorPlaceholderColor;
+  color: @inputErrorPlaceholderColor !important;
 }
 .ui.form .error ::-moz-placeholder {
   color: @inputErrorPlaceholderColor;
@@ -354,7 +354,7 @@
   color: @inputErrorPlaceholderFocusColor;
 }
 .ui.form .error :focus:-ms-input-placeholder {
-  color: @inputErrorPlaceholderFocusColor;
+  color: @inputErrorPlaceholderFocusColor !important;
 }
 .ui.form .error :focus::-moz-placeholder {
   color: @inputErrorPlaceholderFocusColor;

--- a/src/definitions/elements/input.less
+++ b/src/definitions/elements/input.less
@@ -69,7 +69,7 @@
 .ui.input input::-moz-placeholder {
   color: @placeholderColor;
 }
-.ui.input input::-ms-input-placeholder {
+.ui.input input:-ms-input-placeholder {
   color: @placeholderColor;
 }
 
@@ -162,8 +162,8 @@
 .ui.input input:focus::-moz-placeholder {
   color: @placeholderFocusColor;
 }
-.ui.input.focus input::-ms-input-placeholder,
-.ui.input input:focus::-ms-input-placeholder {
+.ui.input.focus input:-ms-input-placeholder,
+.ui.input input:focus:-ms-input-placeholder {
   color: @placeholderFocusColor;
 }
 
@@ -187,7 +187,7 @@
 .ui.input.error input::-moz-placeholder {
   color: @placeholderErrorColor;
 }
-.ui.input.error input::-ms-input-placeholder {
+.ui.input.error input:-ms-input-placeholder {
   color: @placeholderErrorColor;
 }
 
@@ -198,7 +198,7 @@
 .ui.input.error input:focus::-moz-placeholder {
   color: @placeholderErrorFocusColor;
 }
-.ui.input.error input:focus::-ms-input-placeholder {
+.ui.input.error input:focus:-ms-input-placeholder {
   color: @placeholderErrorFocusColor;
 }
 
@@ -245,7 +245,7 @@
 .ui.transparent.inverted.input input::-moz-placeholder {
   color: @transparentInvertedPlaceholderColor;
 }
-.ui.transparent.inverted.input input::-ms-input-placeholder {
+.ui.transparent.inverted.input input:-ms-input-placeholder {
   color: @transparentInvertedPlaceholderColor;
 }
 

--- a/src/definitions/elements/input.less
+++ b/src/definitions/elements/input.less
@@ -188,7 +188,7 @@
   color: @placeholderErrorColor;
 }
 .ui.input.error input:-ms-input-placeholder {
-  color: @placeholderErrorColor;
+  color: @placeholderErrorColor !important;
 }
 
 /* Focused Error Placeholder */
@@ -199,7 +199,7 @@
   color: @placeholderErrorFocusColor;
 }
 .ui.input.error input:focus:-ms-input-placeholder {
-  color: @placeholderErrorFocusColor;
+  color: @placeholderErrorFocusColor !important;
 }
 
 /*******************************


### PR DESCRIPTION
Displayed in Internet Explorer 11, text placeholder looks same as input text. Please check [my fiddle](https://jsfiddle.net/0x9n/3nu66saz/1/) with Internet Explorer 11.

![placeholder](https://cloud.githubusercontent.com/assets/9293024/14609499/0ae52132-05c5-11e6-87ea-a152e5871f17.PNG)
(Screen Capture from my fiddle)

===

This mistake is caused by typo in selecting pseudo class `-ms-input-placeholder`, so I fixed it. When fixing, I looked [this MSDN document](https://msdn.microsoft.com/ja-jp/library/hh772745(v=vs.85).aspx).

And I used `!important` in some error case because I had to get higher specificity than other style like below.

```css
.ui.form .field.error input[type='text']
```