### PR TITLE
Correct ProjectTalk Button link in Readme on NPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 
 [![Join the chat at https://gitter.im/Semantic-Org/Semantic-UI](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/Semantic-Org/Semantic-UI?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-[![ProjectTalk Messageboard](http://www.projecttalk.io/images/gh_badge-3e578a9f437f841de7446bab9a49d103.svg?vsn=d)]
-(http://www.projecttalk.io/boards/Semantic-Org%2FSemantic-UI?utm_campaign=gh-badge&utm_medium=badge&utm_source=github)
+[![ProjectTalk Messageboard](http://www.projecttalk.io/images/gh_badge-3e578a9f437f841de7446bab9a49d103.svg?vsn=d)](http://www.projecttalk.io/boards/Semantic-Org%2FSemantic-UI?utm_campaign=gh-badge&utm_medium=badge&utm_source=github)
 
 Semantic is a UI framework designed for theming.
 


### PR DESCRIPTION
On NPM the projectTalk button link looks like this:

![screen shot 2016-04-29 at 8 42 19 pm](https://cloud.githubusercontent.com/assets/2916945/14933186/ef6ae178-0e4b-11e6-83c6-b489a0f6ecb3.png)

This was caused by an extra line break in the markdown. Github seems to compensate for this automatically, while npm does not. 