### PR TITLE
Dropdown menu tpl disabled attribute fix

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -3416,7 +3416,10 @@ $.fn.dropdown.settings.templates = {
       html   = ''
     ;
     $.each(values, function(index, option) {
-      html += '<div class="item" data-value="' + option[fields.value] + '">' + option[fields.name] + '</div>';
+      html += (option.disabled)
+        ? '<div class="disabled item" data-value="' + option[fields.value] + '">' + option[fields.name] + '</div>'
+        : '<div class="item" data-value="' + option[fields.value] + '">' + option[fields.name] + '</div>'
+      ;
     });
     return html;
   },


### PR DESCRIPTION
When a dropdown menu gets regenerated, menu options loose their "disabled" attribute.

I have added the missing attribute in template string.