### PR TITLE
Update modal.less for inverted modal close button style fix

### DIFF
--- a/src/definitions/modules/modal.less
+++ b/src/definitions/modules/modal.less
@@ -281,6 +281,10 @@
   box-shadow: @invertedBoxShadow;
 }
 
+.ui.inverted.dimmer > .ui.modal > .close {
+  color: @headerColor;
+}
+
 /*******************************
              Types
 *******************************/


### PR DESCRIPTION
When you invert the modal (white background instead of the normal black), any close button that is added comes out white, which isn't helpful.

This change allows for the outer-most close button (as the examples use) to show up as the same colour as the header `rgba(0,0,0,0.87)`
