### PR TITLE
to use the same style for input[type="file"].

### DIFF
--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -89,6 +89,7 @@
 .ui.form input[type="tel"],
 .ui.form input[type="time"],
 .ui.form input[type="text"],
+.ui.form input[type="file"],
 .ui.form input[type="url"] {
   width: @inputWidth;
   vertical-align: top;
@@ -110,6 +111,7 @@
 .ui.form input[type="tel"],
 .ui.form input[type="time"],
 .ui.form input[type="text"],
+.ui.form input[type="file"],
 .ui.form input[type="url"] {
   font-family: @inputFont;
   margin: 0em;
@@ -375,6 +377,7 @@
 .ui.form input[type="tel"]:focus,
 .ui.form input[type="time"]:focus,
 .ui.form input[type="text"]:focus,
+.ui.form input[type="file"]:focus,
 .ui.form input[type="url"]:focus {
   color: @inputFocusColor;
   border-color: @inputFocusBorderColor;
@@ -454,6 +457,7 @@
 .ui.form .fields.error .field input[type="tel"],
 .ui.form .fields.error .field input[type="time"],
 .ui.form .fields.error .field input[type="text"],
+.ui.form .fields.error .field input[type="file"],
 .ui.form .fields.error .field input[type="url"],
 .ui.form .field.error textarea,
 .ui.form .field.error select,
@@ -467,6 +471,7 @@
 .ui.form .field.error input[type="tel"],
 .ui.form .field.error input[type="time"],
 .ui.form .field.error input[type="text"],
+.ui.form .field.error input[type="file"],
 .ui.form .field.error input[type="url"] {
   background: @formErrorBackground;
   border-color: @formErrorBorder;
@@ -486,6 +491,7 @@
 .ui.form .field.error input[type="tel"]:focus,
 .ui.form .field.error input[type="time"]:focus,
 .ui.form .field.error input[type="text"]:focus,
+.ui.form .field.error input[type="file"]:focus,
 .ui.form .field.error input[type="url"]:focus {
   background: @inputErrorFocusBackground;
   border-color: @inputErrorFocusBorder;
@@ -706,6 +712,7 @@
 .ui.inverted.form input[type="tel"],
 .ui.inverted.form input[type="time"],
 .ui.inverted.form input[type="text"],
+.ui.inverted.form input[type="file"],
 .ui.inverted.form input[type="url"] {
   background: @invertedInputBackground;
   border-color: @invertedInputBorderColor;


### PR DESCRIPTION
in form validation, type="file" is working properly but the style doesn't change properly. Because there are missing points. I add css selectors for input[type="file"] in this file so that we can see some 'error' style for input[type="file"] as below.
![screen shot 2016-05-18 at 2 58 00 pm](https://cloud.githubusercontent.com/assets/11525126/15376296/f7f43e72-1d08-11e6-9755-37e292bc036b.png)
