### PR TITLE
Update material theme font URLs to be '//' instead of 'http://'

### DIFF
--- a/src/themes/material/collections/menu.overrides
+++ b/src/themes/material/collections/menu.overrides
@@ -1,1 +1,1 @@
-@import url(http://fonts.googleapis.com/css?family=Roboto);
+@import url(//fonts.googleapis.com/css?family=Roboto);

--- a/src/themes/material/collections/menu.overrides
+++ b/src/themes/material/collections/menu.overrides
@@ -1,1 +1,1 @@
-@import url(//fonts.googleapis.com/css?family=Roboto);
+@import url(https://fonts.googleapis.com/css?family=Roboto);

--- a/src/themes/material/elements/button.overrides
+++ b/src/themes/material/elements/button.overrides
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Roboto);
+@import url(//fonts.googleapis.com/css?family=Roboto);
 
 .ui.primary.button:hover {
   box-shadow:

--- a/src/themes/material/elements/button.overrides
+++ b/src/themes/material/elements/button.overrides
@@ -1,4 +1,4 @@
-@import url(//fonts.googleapis.com/css?family=Roboto);
+@import url(https://fonts.googleapis.com/css?family=Roboto);
 
 .ui.primary.button:hover {
   box-shadow:

--- a/src/themes/material/elements/header.overrides
+++ b/src/themes/material/elements/header.overrides
@@ -2,7 +2,7 @@
            Overrides
 *******************************/
 
-@import url(//fonts.googleapis.com/css?family=Roboto);
+@import url(https://fonts.googleapis.com/css?family=Roboto);
 
 h1.ui.header,
 .ui.huge.header {

--- a/src/themes/material/elements/header.overrides
+++ b/src/themes/material/elements/header.overrides
@@ -2,7 +2,7 @@
            Overrides
 *******************************/
 
-@import url(http://fonts.googleapis.com/css?family=Roboto);
+@import url(//fonts.googleapis.com/css?family=Roboto);
 
 h1.ui.header,
 .ui.huge.header {

--- a/src/themes/material/modules/dropdown.overrides
+++ b/src/themes/material/modules/dropdown.overrides
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Roboto:400,700);
+@import url(//fonts.googleapis.com/css?family=Roboto:400,700);
 
 .ui.dropdown {
   font-family: 'Roboto';

--- a/src/themes/material/modules/dropdown.overrides
+++ b/src/themes/material/modules/dropdown.overrides
@@ -1,4 +1,4 @@
-@import url(//fonts.googleapis.com/css?family=Roboto:400,700);
+@import url(https://fonts.googleapis.com/css?family=Roboto:400,700);
 
 .ui.dropdown {
   font-family: 'Roboto';

--- a/src/themes/material/modules/modal.overrides
+++ b/src/themes/material/modules/modal.overrides
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Roboto);
+@import url(//fonts.googleapis.com/css?family=Roboto);
 
 .ui.modal .header {
   font-family: "Roboto", Arial, Sans-serif !important;

--- a/src/themes/material/modules/modal.overrides
+++ b/src/themes/material/modules/modal.overrides
@@ -1,4 +1,4 @@
-@import url(//fonts.googleapis.com/css?family=Roboto);
+@import url(https://fonts.googleapis.com/css?family=Roboto);
 
 .ui.modal .header {
   font-family: "Roboto", Arial, Sans-serif !important;


### PR DESCRIPTION
The default material theme uses http:// for the fonts in every override file, which throws warnings on SSL enabled sites. This fixes that.