### PR TITLE
Remove duplicated .grid class selectors

### DIFF
--- a/src/definitions/collections/grid.less
+++ b/src/definitions/collections/grid.less
@@ -1790,121 +1790,121 @@
 
 /* Mobile Only Hide */
 @media only screen and (max-width: @largestMobileScreen) {
-  .ui[class*="tablet only"].grid.grid.grid:not(.mobile),
-  .ui.grid.grid.grid > [class*="tablet only"].row:not(.mobile),
-  .ui.grid.grid.grid > [class*="tablet only"].column:not(.mobile),
-  .ui.grid.grid.grid > .row > [class*="tablet only"].column:not(.mobile) {
+  .ui[class*="tablet only"].grid:not(.mobile),
+  .ui.grid > [class*="tablet only"].row:not(.mobile),
+  .ui.grid > [class*="tablet only"].column:not(.mobile),
+  .ui.grid > .row > [class*="tablet only"].column:not(.mobile) {
     display: none !important;
   }
-  .ui[class*="computer only"].grid.grid.grid:not(.mobile),
-  .ui.grid.grid.grid > [class*="computer only"].row:not(.mobile),
-  .ui.grid.grid.grid > [class*="computer only"].column:not(.mobile),
-  .ui.grid.grid.grid > .row > [class*="computer only"].column:not(.mobile) {
+  .ui[class*="computer only"].grid:not(.mobile),
+  .ui.grid > [class*="computer only"].row:not(.mobile),
+  .ui.grid > [class*="computer only"].column:not(.mobile),
+  .ui.grid > .row > [class*="computer only"].column:not(.mobile) {
     display: none !important;
   }
-  .ui[class*="large screen only"].grid.grid.grid:not(.mobile),
-  .ui.grid.grid.grid > [class*="large screen only"].row:not(.mobile),
-  .ui.grid.grid.grid > [class*="large screen only"].column:not(.mobile),
-  .ui.grid.grid.grid > .row > [class*="large screen only"].column:not(.mobile) {
+  .ui[class*="large screen only"].grid:not(.mobile),
+  .ui.grid > [class*="large screen only"].row:not(.mobile),
+  .ui.grid > [class*="large screen only"].column:not(.mobile),
+  .ui.grid > .row > [class*="large screen only"].column:not(.mobile) {
     display: none !important;
   }
-  .ui[class*="widescreen only"].grid.grid.grid:not(.mobile),
-  .ui.grid.grid.grid > [class*="widescreen only"].row:not(.mobile),
-  .ui.grid.grid.grid > [class*="widescreen only"].column:not(.mobile),
-  .ui.grid.grid.grid > .row > [class*="widescreen only"].column:not(.mobile) {
+  .ui[class*="widescreen only"].grid:not(.mobile),
+  .ui.grid > [class*="widescreen only"].row:not(.mobile),
+  .ui.grid > [class*="widescreen only"].column:not(.mobile),
+  .ui.grid > .row > [class*="widescreen only"].column:not(.mobile) {
     display: none !important;
   }
 }
 /* Tablet Only Hide */
 @media only screen and (min-width: @tabletBreakpoint) and (max-width: @largestTabletScreen) {
-  .ui[class*="mobile only"].grid.grid.grid:not(.tablet),
-  .ui.grid.grid.grid > [class*="mobile only"].row:not(.tablet),
-  .ui.grid.grid.grid > [class*="mobile only"].column:not(.tablet),
-  .ui.grid.grid.grid > .row > [class*="mobile only"].column:not(.tablet) {
+  .ui[class*="mobile only"].grid:not(.tablet),
+  .ui.grid > [class*="mobile only"].row:not(.tablet),
+  .ui.grid > [class*="mobile only"].column:not(.tablet),
+  .ui.grid > .row > [class*="mobile only"].column:not(.tablet) {
     display: none !important;
   }
-  .ui[class*="computer only"].grid.grid.grid:not(.tablet),
-  .ui.grid.grid.grid > [class*="computer only"].row:not(.tablet),
-  .ui.grid.grid.grid > [class*="computer only"].column:not(.tablet),
-  .ui.grid.grid.grid > .row > [class*="computer only"].column:not(.tablet) {
+  .ui[class*="computer only"].grid:not(.tablet),
+  .ui.grid > [class*="computer only"].row:not(.tablet),
+  .ui.grid > [class*="computer only"].column:not(.tablet),
+  .ui.grid > .row > [class*="computer only"].column:not(.tablet) {
     display: none !important;
   }
-  .ui[class*="large screen only"].grid.grid.grid:not(.mobile),
-  .ui.grid.grid.grid > [class*="large screen only"].row:not(.mobile),
-  .ui.grid.grid.grid > [class*="large screen only"].column:not(.mobile),
-  .ui.grid.grid.grid > .row > [class*="large screen only"].column:not(.mobile) {
+  .ui[class*="large screen only"].grid:not(.mobile),
+  .ui.grid > [class*="large screen only"].row:not(.mobile),
+  .ui.grid > [class*="large screen only"].column:not(.mobile),
+  .ui.grid > .row > [class*="large screen only"].column:not(.mobile) {
     display: none !important;
   }
-  .ui[class*="widescreen only"].grid.grid.grid:not(.mobile),
-  .ui.grid.grid.grid > [class*="widescreen only"].row:not(.mobile),
-  .ui.grid.grid.grid > [class*="widescreen only"].column:not(.mobile),
-  .ui.grid.grid.grid > .row > [class*="widescreen only"].column:not(.mobile) {
+  .ui[class*="widescreen only"].grid:not(.mobile),
+  .ui.grid > [class*="widescreen only"].row:not(.mobile),
+  .ui.grid > [class*="widescreen only"].column:not(.mobile),
+  .ui.grid > .row > [class*="widescreen only"].column:not(.mobile) {
     display: none !important;
   }
 }
 
 /* Computer Only Hide */
 @media only screen and (min-width: @computerBreakpoint) and (max-width: @largestSmallMonitor) {
-  .ui[class*="mobile only"].grid.grid.grid:not(.computer),
-  .ui.grid.grid.grid > [class*="mobile only"].row:not(.computer),
-  .ui.grid.grid.grid > [class*="mobile only"].column:not(.computer),
-  .ui.grid.grid.grid > .row > [class*="mobile only"].column:not(.computer) {
+  .ui[class*="mobile only"].grid:not(.computer),
+  .ui.grid > [class*="mobile only"].row:not(.computer),
+  .ui.grid > [class*="mobile only"].column:not(.computer),
+  .ui.grid > .row > [class*="mobile only"].column:not(.computer) {
     display: none !important;
   }
-  .ui[class*="tablet only"].grid.grid.grid:not(.computer),
-  .ui.grid.grid.grid > [class*="tablet only"].row:not(.computer),
-  .ui.grid.grid.grid > [class*="tablet only"].column:not(.computer),
-  .ui.grid.grid.grid > .row > [class*="tablet only"].column:not(.computer) {
+  .ui[class*="tablet only"].grid:not(.computer),
+  .ui.grid > [class*="tablet only"].row:not(.computer),
+  .ui.grid > [class*="tablet only"].column:not(.computer),
+  .ui.grid > .row > [class*="tablet only"].column:not(.computer) {
     display: none !important;
   }
-  .ui[class*="large screen only"].grid.grid.grid:not(.mobile),
-  .ui.grid.grid.grid > [class*="large screen only"].row:not(.mobile),
-  .ui.grid.grid.grid > [class*="large screen only"].column:not(.mobile),
-  .ui.grid.grid.grid > .row > [class*="large screen only"].column:not(.mobile) {
+  .ui[class*="large screen only"].grid:not(.mobile),
+  .ui.grid > [class*="large screen only"].row:not(.mobile),
+  .ui.grid > [class*="large screen only"].column:not(.mobile),
+  .ui.grid > .row > [class*="large screen only"].column:not(.mobile) {
     display: none !important;
   }
-  .ui[class*="widescreen only"].grid.grid.grid:not(.mobile),
-  .ui.grid.grid.grid > [class*="widescreen only"].row:not(.mobile),
-  .ui.grid.grid.grid > [class*="widescreen only"].column:not(.mobile),
-  .ui.grid.grid.grid > .row > [class*="widescreen only"].column:not(.mobile) {
+  .ui[class*="widescreen only"].grid:not(.mobile),
+  .ui.grid > [class*="widescreen only"].row:not(.mobile),
+  .ui.grid > [class*="widescreen only"].column:not(.mobile),
+  .ui.grid > .row > [class*="widescreen only"].column:not(.mobile) {
     display: none !important;
   }
 }
 
 /* Large Screen Only Hide */
 @media only screen and (min-width: @largeMonitorBreakpoint) and (max-width: @largestLargeMonitor) {
-  .ui[class*="mobile only"].grid.grid.grid:not(.computer),
-  .ui.grid.grid.grid > [class*="mobile only"].row:not(.computer),
-  .ui.grid.grid.grid > [class*="mobile only"].column:not(.computer),
-  .ui.grid.grid.grid > .row > [class*="mobile only"].column:not(.computer) {
+  .ui[class*="mobile only"].grid:not(.computer),
+  .ui.grid > [class*="mobile only"].row:not(.computer),
+  .ui.grid > [class*="mobile only"].column:not(.computer),
+  .ui.grid > .row > [class*="mobile only"].column:not(.computer) {
     display: none !important;
   }
-  .ui[class*="tablet only"].grid.grid.grid:not(.computer),
-  .ui.grid.grid.grid > [class*="tablet only"].row:not(.computer),
-  .ui.grid.grid.grid > [class*="tablet only"].column:not(.computer),
-  .ui.grid.grid.grid > .row > [class*="tablet only"].column:not(.computer) {
+  .ui[class*="tablet only"].grid:not(.computer),
+  .ui.grid > [class*="tablet only"].row:not(.computer),
+  .ui.grid > [class*="tablet only"].column:not(.computer),
+  .ui.grid > .row > [class*="tablet only"].column:not(.computer) {
     display: none !important;
   }
-  .ui[class*="widescreen only"].grid.grid.grid:not(.mobile),
-  .ui.grid.grid.grid > [class*="widescreen only"].row:not(.mobile),
-  .ui.grid.grid.grid > [class*="widescreen only"].column:not(.mobile),
-  .ui.grid.grid.grid > .row > [class*="widescreen only"].column:not(.mobile) {
+  .ui[class*="widescreen only"].grid:not(.mobile),
+  .ui.grid > [class*="widescreen only"].row:not(.mobile),
+  .ui.grid > [class*="widescreen only"].column:not(.mobile),
+  .ui.grid > .row > [class*="widescreen only"].column:not(.mobile) {
     display: none !important;
   }
 }
 
 /* Widescreen Only Hide */
 @media only screen and (min-width: @widescreenMonitorBreakpoint) {
-  .ui[class*="mobile only"].grid.grid.grid:not(.computer),
-  .ui.grid.grid.grid > [class*="mobile only"].row:not(.computer),
-  .ui.grid.grid.grid > [class*="mobile only"].column:not(.computer),
-  .ui.grid.grid.grid > .row > [class*="mobile only"].column:not(.computer) {
+  .ui[class*="mobile only"].grid:not(.computer),
+  .ui.grid > [class*="mobile only"].row:not(.computer),
+  .ui.grid > [class*="mobile only"].column:not(.computer),
+  .ui.grid > .row > [class*="mobile only"].column:not(.computer) {
     display: none !important;
   }
-  .ui[class*="tablet only"].grid.grid.grid:not(.computer),
-  .ui.grid.grid.grid > [class*="tablet only"].row:not(.computer),
-  .ui.grid.grid.grid > [class*="tablet only"].column:not(.computer),
-  .ui.grid.grid.grid > .row > [class*="tablet only"].column:not(.computer) {
+  .ui[class*="tablet only"].grid:not(.computer),
+  .ui.grid > [class*="tablet only"].row:not(.computer),
+  .ui.grid > [class*="tablet only"].column:not(.computer),
+  .ui.grid > .row > [class*="tablet only"].column:not(.computer) {
     display: none !important;
   }
 }


### PR DESCRIPTION
Maybe I'm misunderstanding something but it seems like ".ui.grid.grid.grid" is redundant and could be replaced with ".ui.grid"