### PR TITLE
No margin-right for children of .meta

### DIFF
--- a/src/definitions/views/item.less
+++ b/src/definitions/views/item.less
@@ -213,8 +213,11 @@
   line-height: @metaLineHeight;
   color: @metaColor;
 }
-.ui.items > .item .meta *:not(time) {
+.ui.items > .item .meta * {
   margin-right: @metaSpacing;
+}
+.ui.items > .item .meta > * {
+  margin-right: 0em;
 }
 .ui.items > .item .meta :last-child {
   margin-right: 0em;

--- a/src/definitions/views/item.less
+++ b/src/definitions/views/item.less
@@ -213,7 +213,7 @@
   line-height: @metaLineHeight;
   color: @metaColor;
 }
-.ui.items > .item .meta * {
+.ui.items > .item .meta *:not(time) {
   margin-right: @metaSpacing;
 }
 .ui.items > .item .meta :last-child {


### PR DESCRIPTION
Fix for  #4062 

http://jsfiddle.net/lixonic/tfm7qxzz/7/ 

![agobug](https://cloud.githubusercontent.com/assets/934220/15799774/1d218022-2a85-11e6-8e94-223a67f312d5.png)
