### PR TITLE
Let onRate know if it's the initial call

### DIFF
--- a/src/definitions/modules/rating.js
+++ b/src/definitions/modules/rating.js
@@ -66,7 +66,7 @@ $.fn.rating = function(parameters) {
           else {
             module.disable();
           }
-          module.set.rating( module.get.initialRating() );
+          module.set.rating( module.get.initialRating(), true );
           module.instantiate();
         },
 
@@ -214,7 +214,7 @@ $.fn.rating = function(parameters) {
         },
 
         set: {
-          rating: function(rating) {
+          rating: function(rating, initialRating) {
             var
               ratingIndex = (rating - 1 >= 0)
                 ? (rating - 1)
@@ -236,7 +236,7 @@ $.fn.rating = function(parameters) {
                   .addClass(className.active)
               ;
             }
-            settings.onRate.call(element, rating);
+            settings.onRate.call(element, rating, initialRating);
           }
         },
 


### PR DESCRIPTION
Setting an initial rating on a rating element calls into onRate. This is an issue within my ember component as this will not be allowed in Ember 3.0 as my onRate function mutates the component's values within the render event. This is probably not the optimal way to handle this, but it allows the user to choose to do something, if at all, due to this event.