### PR TITLE
[Menu] @dividerSize cannot be changed since it is hard coded

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -538,7 +538,6 @@ Floated Menu / Item
   width: 100%;
   height: @dividerSize;
   background: @verticalDividerBackground;
-  height: 1px;
 }
 
 .ui.vertical.menu .item:first-child:before {
@@ -1230,7 +1229,6 @@ Floated Menu / Item
     width: 100%;
     height: @dividerSize;
     background: @verticalDividerBackground;
-    height: 1px;
   }
 }
 


### PR DESCRIPTION
Removed duplicate height definition to respect the `@dividerSize` variable