### PR TITLE
Fix compact form messages

### DIFF
--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -400,6 +400,9 @@
 .ui.form.success .success.message:not(:empty) {
   display: block;
 }
+.ui.form.success .compact.success.message:not(:empty) {
+  display: inline-block;
+}
 .ui.form.success .icon.success.message:not(:empty) {
   display: flex;
 }
@@ -412,6 +415,9 @@
 .ui.form.warning .warning.message:not(:empty) {
   display: block;
 }
+.ui.form.warning .compact.warning.message:not(:empty) {
+  display: inline-block;
+}
 .ui.form.warning .icon.warning.message:not(:empty) {
   display: flex;
 }
@@ -423,6 +429,9 @@
 /* On Form */
 .ui.form.error .error.message:not(:empty) {
   display: block;
+}
+.ui.form.error .compact.error.message:not(:empty) {
+  display: inline-block;
 }
 .ui.form.error .icon.error.message:not(:empty) {
   display: flex;


### PR DESCRIPTION
Add inline-block to compact form messages so they don't take the full width of their container.

Fixes #3343