### PR TITLE
[Icon Input] Fix for issue #4057

### DIFF
--- a/src/definitions/elements/input.less
+++ b/src/definitions/elements/input.less
@@ -273,7 +273,7 @@
 .ui.icon.input > i.icon:not(.link) {
   pointer-events: none;
 }
-.ui.icon.input input {
+.ui.icon.input > input {
   padding-right: @iconMargin !important;
 }
 


### PR DESCRIPTION
A fix for my own issue #4057 which pertained to having a multiple select dropdown inside a popup that was attached to an icon input.

The fix is that an icon input applies padding-right: @iconMargin !important; to all input children of an icon input. This caused problems with the inputs inside the popup which also received this padding. This also caused the search input text to disappear in the multiple select within the popup.
