### PR TITLE
[Icon] Path to 'Icons' font should not contain backslashes

### DIFF
--- a/tasks/config/project/config.js
+++ b/tasks/config/project/config.js
@@ -92,9 +92,9 @@ module.exports = {
 
     config.paths.assets = {
       source       : '../../themes', // source asset path is always the same
-      uncompressed : '.' + path.sep + path.relative(config.paths.output.uncompressed, config.paths.output.themes).replace(/\\/g, '/'),
-      compressed   : '.' + path.sep + path.relative(config.paths.output.compressed, config.paths.output.themes).replace(/\\/g, '/'),
-      packaged     : '.' + path.sep + path.relative(config.paths.output.packaged, config.paths.output.themes).replace(/\\/g, '/')
+      uncompressed : './' + path.relative(config.paths.output.uncompressed, config.paths.output.themes).replace(/\\/g, '/'),
+      compressed   : './' + path.relative(config.paths.output.compressed, config.paths.output.themes).replace(/\\/g, '/'),
+      packaged     : './' + path.relative(config.paths.output.packaged, config.paths.output.themes).replace(/\\/g, '/')
     };
 
     /*--------------


### PR DESCRIPTION
Replace path.sep with '/' char for build correctly under Windows (default path.sep == '\')
