### PR TITLE
[Dropdown] Disconnect.selectObserver bugfix

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -154,8 +154,8 @@ $.fn.dropdown = function(parameters) {
             }
           },
           selectObserver: function() {
-            if(menuObserver) {
-              menuObserver.disconnect();
+            if(selectObserver) {
+              selectObserver.disconnect();
             }
           }
         },


### PR DESCRIPTION
Dropdown function 'disconnect.selectObserver' trying to disconnect menuObserver instead.