### PR TITLE
[Icons] Removed duplicated 'talk' icon with incorrect content

### DIFF
--- a/src/themes/default/elements/icon.overrides
+++ b/src/themes/default/elements/icon.overrides
@@ -753,7 +753,6 @@ i.icon.attention:before { content: "\f06a"; }
 i.icon.eye:before { content: "\f06e"; }
 i.icon.exclamation.triangle:before { content: "\f071"; }
 i.icon.shuffle:before { content: "\f074"; }
-i.icon.talk:before { content: "\f075"; }
 i.icon.chat:before { content: "\f075"; }
 i.icon.cart:before { content: "\f07a"; }
 i.icon.shopping.cart:before { content: "\f07a"; }


### PR DESCRIPTION
` i.icon.talk:before { content: "\f27a"; }` was re-declared in "Aliases" section with different content value `"\f075"`.
The alias was overriding the correctly declared talk icon.
You can look in the docs http://semantic-ui.com/elements/icon.html, the "Talk" icon should be same as "Talk Outline" (with just the outline of course).