### PR TITLE
[Icon] Fixes typos

### DIFF
--- a/src/themes/default/elements/icon.overrides
+++ b/src/themes/default/elements/icon.overrides
@@ -909,11 +909,11 @@ i.icon.hourglass.one:before { content: "\f251"; }
 i.icon.hourglass.two:before { content: "\f252"; }
 i.icon.hourglass.three:before { content: "\f253"; }
 i.icon.hourglass.four:before { content: "\f254"; }
-i.icon.grab { content: "\f255"; }
+i.icon.grab:before { content: "\f255"; }
 i.icon.hand.victory:before { content: "\f25b"; }
 i.icon.tm:before { content: "\f25c"; }
 i.icon.r.circle:before { content: "\f25d"; }
-i.icon.television { content: "\f26c"; }
+i.icon.television:before { content: "\f26c"; }
 i.icon.five.hundred.pixels:before { content: "\f26e"; }
 i.icon.calendar.plus:before { content: "\f271"; }
 i.icon.calendar.minus:before { content: "\f272"; }


### PR DESCRIPTION
Now `grab` and `television` have the proper icon definitions.

> It just happened. I don't know what to say...