### PR TITLE
Removing comments icon WRONG sizing .css classes + Typo fixes

### DIFF
--- a/dist/components/comment.css
+++ b/dist/components/comment.css
@@ -225,27 +225,10 @@
   -webkit-transition-delay: 0.1s;
           transition-delay: 0.1s;
 }
+
 .ui.minimal.comments .comment > .content:hover > .actions {
   opacity: 1;
 }
-
-/*--------------------
-       Sizes
----------------------*/
-
-.ui.small.comments {
-  font-size: 0.9em;
-}
-.ui.comments {
-  font-size: 1em;
-}
-.ui.large.comments {
-  font-size: 1.1em;
-}
-.ui.huge.comments {
-  font-size: 1.2em;
-}
-
 
 /*******************************
          Theme Overrides

--- a/dist/components/form.css
+++ b/dist/components/form.css
@@ -589,7 +589,7 @@
 .ui.loading.form {
   position: relative;
   cursor: default;
-  point-events: none;
+  pointer-events: none;
 }
 .ui.loading.form:before {
   position: absolute;

--- a/dist/components/segment.css
+++ b/dist/components/segment.css
@@ -409,7 +409,7 @@
 .ui.loading.segment {
   position: relative;
   cursor: default;
-  point-events: none;
+  pointer-events: none;
   text-shadow: none !important;
   color: transparent !important;
   -webkit-transition: all 0s linear;

--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -598,7 +598,7 @@
 .ui.loading.form {
   position: relative;
   cursor: default;
-  point-events: none;
+  pointer-events: none;
 }
 .ui.loading.form:before {
   position: absolute;

--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -400,7 +400,7 @@
 .ui.loading.segment {
   position: relative;
   cursor: default;
-  point-events: none;
+  pointer-events: none;
   text-shadow: none !important;
   color: transparent !important;
   transition: all 0s linear;


### PR DESCRIPTION
Comments icon already has sizing coming from 'src/definitions/elements/icon.less' this rules here overwrite it and display WRONG comments icon sizing.