### PR TITLE
'on: change' causes error prompts to appear when blurring field 

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -326,7 +326,7 @@ $.fn.form = function(parameters) {
                   module.validate.field( validationRules );
                 }
               }
-              else if(settings.on == 'blur' || settings.on == 'change') {
+              else if(settings.on == 'blur') {
                 if(validationRules) {
                   module.validate.field( validationRules );
                 }


### PR DESCRIPTION
https://github.com/Semantic-Org/Semantic-UI/issues/4422
