### PR TITLE
Fix fg-color on inverted forms in flat theme.

### DIFF
--- a/src/themes/flat/collections/form.variables
+++ b/src/themes/flat/collections/form.variables
@@ -25,6 +25,7 @@
 @inputBorder: none;
 @inputBorderRadius: 0em;
 @inputBoxShadow: none;
+@invertedInputColor: @invertedTextColor;
 
 @textAreaPadding: 1em;
 @textAreaBackground: transparent;


### PR DESCRIPTION
This is an attempted fix for #1802, which was closed as a `Cannot fix`.

# Original version

![](http://i.imgur.com/LZ7hwf7.png)

On the current website, with the Flat theme selected.

# Fixed version
![](http://i.imgur.com/8qq9cmm.png)