### PR TITLE
Take content settings before attr title

### DIFF
--- a/src/definitions/modules/popup.js
+++ b/src/definitions/modules/popup.js
@@ -488,7 +488,7 @@ $.fn.popup = function(parameters) {
           },
           content: function() {
             $module.removeData(metadata.content);
-            return $module.data(metadata.content) || $module.attr('title') || settings.content;
+            return $module.data(metadata.content) || settings.content || $module.attr('title');
           },
           variation: function() {
             $module.removeData(metadata.variation);


### PR DESCRIPTION
Since settings starts off as false, if it was passed in, it should be taken before title is returned. Workflow should still stay the same, since settings.content false would still default to title. 
