### PR TITLE
Added 4 positions for corner icons

### DIFF
--- a/src/definitions/elements/icon.less
+++ b/src/definitions/elements/icon.less
@@ -469,6 +469,30 @@ i.icons .corner.icon {
   font-size: @cornerIconSize;
   text-shadow: @cornerIconShadow;
 }
+i.icons .top.right.corner.icon {
+  top: 0;
+  left: auto;
+  right: 0;
+  bottom: auto;
+}
+i.icons .top.left.corner.icon {
+  top: 0;
+  left: 0;
+  right: auto;
+  bottom: auto;
+}
+i.icons .bottom.left.corner.icon {
+  top: auto;
+  left: 0;
+  right: auto;
+  bottom: 0;
+}
+i.icons .bottom.right.corner.icon {
+  top: auto;
+  left: auto;
+  right: 0;
+  bottom: 0;
+}
 
 i.icons .inverted.corner.icon {
   text-shadow: @cornerIconInvertedShadow;


### PR DESCRIPTION
Related to requests from issue #904 , added position classes for corner icons (top right, top left, bottom right, bottom left)

<img width="254" alt="screen shot 2016-10-15 at 1 05 03 pm" src="https://cloud.githubusercontent.com/assets/4985688/19413054/2e8da9ec-92d8-11e6-9170-bcead4f69d11.png">
