### PR TITLE
#4506 do not change selection when previously selected element is unfiltered

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -263,6 +263,15 @@ $.fn.dropdown = function(parameters) {
 
         select: {
           firstUnfiltered: function() {
+            module.verbose('Ensuring that an unfiltered option is selected');
+            var visibleExistingSelectedItem = $item.filter(
+                '.' + className.selected +
+                ':not(.' + className.filtered + ')' +
+                ':not(.' + className.disabled + ')');
+            if (visibleExistingSelectedItem.length) {
+              module.verbose('Previously selected element is unfiltered, not changing selection');
+              return;
+            }
             module.verbose('Selecting first non-filtered element');
             module.remove.selectedItem();
             $item


### PR DESCRIPTION
firstUnfiltered() forced change of selection even if previously selected element was visible. This meant that when tabbing through the field, the selected option was changed to first visible.