### PR TITLE
Slider: bugfix and improving implements

### DIFF
--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -342,7 +342,7 @@ $.fn.slider = function(parameters) {
           move: function(event, originalEvent) {
             event.preventDefault();
             var value = module.determine.valueFromEvent(event, originalEvent);
-            if(module.get.step() == 0 || settings.smooth) {
+            if(module.get.step() == 0 || module.is.smooth()) {
               var
                 thumbVal = module.thumbVal,
                 secondThumbVal = module.secondThumbVal,
@@ -456,9 +456,12 @@ $.fn.slider = function(parameters) {
           vertical: function() {
             return $module.hasClass(settings.className.vertical);
           },
+          smooth: function() {
+            return settings.smooth || $module.hasClass(settings.className.smooth);
+          },
           touch: function() {
             return isTouch;
-          },
+          }
         },
 
         get: {
@@ -1182,7 +1185,8 @@ $.fn.slider.settings = {
     disabled : 'disabled',
     labeled  : 'labeled',
     vertical : 'vertical',
-    doubled  : 'double'
+    doubled  : 'double',
+    smooth   : 'smooth'
   },
 
   keys : {

--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -48,8 +48,8 @@ $.fn.slider = function(parameters) {
 
       var
         settings        = ( $.isPlainObject(parameters) )
-          ? $.extend(true, {}, $.fn.range.settings, parameters)
-          : $.extend({}, $.fn.range.settings),
+          ? $.extend(true, {}, $.fn.slider.settings, parameters)
+          : $.extend({}, $.fn.slider.settings),
 
         className       = settings.className,
         metadata        = settings.metadata,

--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -165,8 +165,9 @@ $.fn.slider = function(parameters) {
             $thumb = $module.find('.thumb:not(.second)');
             $currThumb = $thumb;
             if(module.is.doubled()) {
-              if($module.find('.thumb.second').length == 0)
+              if($module.find('.thumb.second').length == 0) {
                 $module.find('.inner').append("<div class='thumb second'></div>");
+              }
               $secondThumb = $module.find('.thumb.second');
             }
             $track = $module.find('.track');
@@ -223,10 +224,12 @@ $.fn.slider = function(parameters) {
           autoLabel: function() {
             if(module.get.step() != 0) {
               $labels = $module.find('.labels');
-              if($labels.length != 0)
+              if($labels.length != 0) {
                 $labels.empty();
-              else
+              }
+              else {
                 $labels = $module.append('<ul class="auto labels"></ul>').find('.labels');
+              }
               for(var i = 0; i <= module.get.numLabels(); i++) {
                 var
                   $label = $('<li class="label">' + module.get.label(i+1) + '</li>'),
@@ -339,8 +342,9 @@ $.fn.slider = function(parameters) {
               ;
               $currThumb = module.determine.closestThumb(newPos);
             }
-            if(!module.is.disabled())
+            if(!module.is.disabled()) {
               module.bind.slidingEvents();
+            }
           },
           move: function(event, originalEvent) {
             event.preventDefault();
@@ -419,8 +423,9 @@ $.fn.slider = function(parameters) {
             currValue = module.get.currentThumbValue()
           ;
           module.verbose('Taking a step');
-          if(step > 0)
+          if(step > 0) {
             module.set.value(currValue + step * multiplier);
+          }
         },
 
         backStep: function(multiplier) {
@@ -430,8 +435,9 @@ $.fn.slider = function(parameters) {
             currValue = module.get.currentThumbValue()
           ;
           module.verbose('Going back a step');
-          if(step > 0)
+          if(step > 0) {
             module.set.value(currValue - step * multiplier);
+          }
         },
 
         is: {
@@ -541,8 +547,9 @@ $.fn.slider = function(parameters) {
             return value;
           },
           currentThumbValue: function() {
-            if($currThumb.hasClass('second'))
+            if($currThumb.hasClass('second')) {
               return module.secondThumbVal;
+            }
             return module.thumbVal;
           },
           thumbValue: function(which) {
@@ -550,8 +557,9 @@ $.fn.slider = function(parameters) {
               case 'first':
                 return module.thumbVal;
               case 'second':
-              if(module.is.doubled())
+              if(module.is.doubled()) {
                 return module.secondThumbVal;
+              }
               else {
                 module.error(error.notdouble);
                 break;
@@ -568,8 +576,9 @@ $.fn.slider = function(parameters) {
               case 'first':
                 return position;
               case 'second':
-                if(module.is.doubled())
+                if(module.is.doubled()) {
                   return secondPos;
+                }
                 else {
                   module.error(error.notdouble);
                   break;
@@ -658,7 +667,9 @@ $.fn.slider = function(parameters) {
               difference = (step == 0) ? value : Math.round(value / step) * step
             ;
             module.verbose('Determined value based upon position: ' + position + ' as: ' + value);
-            if(value != difference) module.verbose('Rounding value to closest step: ' + difference);
+            if(value != difference) {
+              module.verbose('Rounding value to closest step: ' + difference);
+            }
             // Use precision to avoid ugly Javascript floating point rounding issues
             // (like 35 * .01 = 0.35000000000000003)
             difference = Math.round(difference * precision) / precision;
@@ -789,16 +800,19 @@ $.fn.slider = function(parameters) {
               value = Math.abs(module.thumbVal - module.secondThumbVal);
             }
             module.debug('Setting range value to ' + value);
-            if(typeof callback === 'function')
+            if(typeof callback === 'function') {
               callback(value);
+            }
           },
           position: function(newPos, $element) {
             var $targetThumb = $element != undefined ? $element : $currThumb;
             if(module.is.doubled()) {
-              if(!$targetThumb.hasClass('second'))
+              if(!$targetThumb.hasClass('second')) {
                 position = newPos;
-              else
+              }
+              else {
                 secondPos = newPos;
+              }
             } else {
               position = newPos;
             }
@@ -810,25 +824,29 @@ $.fn.slider = function(parameters) {
             if (module.is.vertical()) {
               if (module.is.reversed()) {
                 $targetThumb.css({bottom: String(newPos - offset) + 'px'});
-                if(module.is.doubled())
+                if(module.is.doubled()) {
                   trackPosValue = {bottom: String(parseFloat(module.determine.closestThumbPos(0)) + offset) + 'px'};
+                }
               }
               else {
                 $targetThumb.css({top: String(newPos - offset) + 'px'});
-                if(module.is.doubled())
+                if(module.is.doubled()) {
                   trackPosValue = {top: String(parseFloat(module.determine.closestThumbPos(0)) + offset) + 'px'};
+                }
               }
               $trackFill.css(Object.assign({height: String(trackFillWidth) + 'px'}, trackPosValue));
             } else {
               if (module.is.reversed()) {
                 $targetThumb.css({right: String(newPos - offset) + 'px'});
-                if(module.is.doubled())
+                if(module.is.doubled()) {
                   trackPosValue = {right: String(parseFloat(module.determine.closestThumbPos(0)) + offset) + 'px'};
+                }
               }
               else {
                 $targetThumb.css({left: String(newPos - offset) + 'px'});
-                if(module.is.doubled())
+                if(module.is.doubled()) {
                   trackPosValue = {left: String(parseFloat(module.determine.closestThumbPos(0)) + offset) + 'px'};
+                }
               }
               $trackFill.css(Object.assign({width: String(trackFillWidth) + 'px'}, trackPosValue));
             }

--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -138,6 +138,9 @@ $.fn.slider = function(parameters) {
           slider: function() {
             sliderObserver.observe($module[0], {
               attributes: true,
+              // It will be better if CSS style changes can be observed,
+              // see http://xml3d.org/xml3d/specification/styleobserver
+              attributeFilter: ['class', 'style']
             });
           },
         },

--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -159,7 +159,11 @@ $.fn.slider = function(parameters) {
               $module.attr('tabindex', 0);
             }
             if($module.find('.inner').length == 0) {
-              $module.append("<div class='inner'><div class='track'></div><div class='track-fill'></div><div class='thumb'></div></div>");
+              $module.append("<div class='inner'>"
+                             + "<div class='track'></div>"
+                             + "<div class='track-fill'></div>"
+                             + "<div class='thumb'></div>"
+                             + "</div>");
             }
             precision = module.get.precision();
             $thumb = $module.find('.thumb:not(.second)');
@@ -172,7 +176,7 @@ $.fn.slider = function(parameters) {
             }
             $track = $module.find('.track');
             $trackFill = $module.find('.track-fill');
-            offset = $thumb.width()/2;
+            offset = $thumb.width() / 2;
             module.setup.labels();
           },
           labels: function() {
@@ -533,7 +537,7 @@ $.fn.slider = function(parameters) {
               case settings.labelTypes.number:
                 return (value * module.get.step()) + module.get.min();
               case settings.labelTypes.letter:
-                return alphabet[(value-1)%26];
+                return alphabet[(value - 1) % 26];
               case settings.labelTypes.none:
                 return '';
               default:
@@ -544,23 +548,19 @@ $.fn.slider = function(parameters) {
             return value;
           },
           currentThumbValue: function() {
-            if($currThumb.hasClass('second')) {
-              return module.secondThumbVal;
-            }
-            return module.thumbVal;
+            return $currThumb.hasClass('second') ? module.secondThumbVal : module.thumbVal;
           },
           thumbValue: function(which) {
             switch(which) {
-              case 'first':
-                return module.thumbVal;
               case 'second':
-              if(module.is.doubled()) {
-                return module.secondThumbVal;
-              }
-              else {
-                module.error(error.notdouble);
-                break;
-              }
+                if(module.is.doubled()) {
+                  return module.secondThumbVal;
+                }
+                else {
+                  module.error(error.notdouble);
+                  break;
+                }
+              case 'first':
               default:
                 return module.thumbVal;
             }
@@ -570,8 +570,6 @@ $.fn.slider = function(parameters) {
           },
           thumbPosition: function(which) {
             switch(which) {
-              case 'first':
-                return position;
               case 'second':
                 if(module.is.doubled()) {
                   return secondPos;
@@ -580,15 +578,21 @@ $.fn.slider = function(parameters) {
                   module.error(error.notdouble);
                   break;
                 }
+              case 'first':
               default:
                 return position;
             }
-          },
+          }
         },
 
         determine: {
           pos: function(pagePos) {
-            return module.is.reversed() ? module.get.trackStartPos() - pagePos + module.get.trackOffset() : pagePos - module.get.trackOffset() - module.get.trackStartPos();
+            return module.is.reversed()
+              ?
+              module.get.trackStartPos() - pagePos + module.get.trackOffset()
+              :
+              pagePos - module.get.trackOffset() - module.get.trackStartPos()
+            ;
           },
           closestThumb: function(eventPos) {
             var
@@ -739,15 +743,12 @@ $.fn.slider = function(parameters) {
             max = module.get.max(),
             newPos
           ;
-          if(val >= min && val <= max) {
-            newPos = module.determine.positionFromValue(val);
-          } else if (val <= min) {
-            newPos = module.determine.positionFromValue(min);
+          if (val <= min) {
             val = min;
-          } else {
-            newPos = module.determine.positionFromValue(max);
+          } else if (val >= max) {
             val = max;
           }
+          newPos = module.determine.positionFromValue(val);
           return newPos;
         },
 

--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -820,8 +820,8 @@ $.fn.slider = function(parameters) {
             var
               newPos = module.handleNewValuePosition(newValue),
               $targetThumb = $element != undefined ? $element : $currThumb,
-              thumbVal = module.thumbVal || 0,
-              secondThumbVal = module.secondThumbVal || 0
+              thumbVal = module.thumbVal || module.get.min(),
+              secondThumbVal = module.secondThumbVal || module.get.min()
             ;
             if(module.is.doubled()) {
               if(!$targetThumb.hasClass('second')) {
@@ -840,9 +840,9 @@ $.fn.slider = function(parameters) {
               thumbPosValue,
               min = module.get.min(),
               max = module.get.max(),
-              thumbPosPercent = 100 * newValue / (max - min),
-              trackStartPosPercent = 100 * Math.min(thumbVal, secondThumbVal) / (max - min),
-              trackEndPosPercent = 100 * (1 - Math.max(thumbVal, secondThumbVal) / (max - min))
+              thumbPosPercent = 100 * (newValue - min) / (max - min),
+              trackStartPosPercent = 100 * (Math.min(thumbVal, secondThumbVal) - min) / (max - min),
+              trackEndPosPercent = 100 * (1 - (Math.max(thumbVal, secondThumbVal) - min) / (max - min))
             ;
             if (module.is.vertical()) {
               if (module.is.reversed()) {

--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -197,28 +197,22 @@ $.fn.slider = function(parameters) {
             var
               $children   = $labels.find('.label'),
               numChildren = $children.length,
-              ratio,
-              position
+              min         = module.get.min(),
+              max         = module.get.max(),
+              ratio
             ;
             $children.each(function(index) {
               var
-                $child = $(this),
+                $child    = $(this),
                 attrValue = $child.attr('data-value')
               ;
               if(attrValue) {
-                position = module.determine.positionFromValue(attrValue)
+                attrValue = attrValue > max ? max : attrValue < min ? min : attrValue;
+                ratio = (attrValue - min) / (max - min);
               } else {
-                ratio = ((index+1)/(numChildren+1));
-                position = module.determine.positionFromRatio(ratio);
+                ratio = (index + 1) / (numChildren + 1);
               }
-              var posDir =
-                module.is.vertical()
-                ?
-                module.is.reversed() ? 'bottom' : 'top'
-                :
-                module.is.reversed() ? 'right' : 'left'
-              ;
-              $(this).css(posDir, position);
+              module.update.labelPosition(ratio, $(this));
             });
           },
           autoLabel: function() {
@@ -230,17 +224,12 @@ $.fn.slider = function(parameters) {
               else {
                 $labels = $module.append('<ul class="auto labels"></ul>').find('.labels');
               }
-              for(var i = 0; i <= module.get.numLabels(); i++) {
+              for(var i = 1, len = module.get.numLabels(); i <= len; i++) {
                 var
-                  $label = $('<li class="label">' + module.get.label(i+1) + '</li>'),
-                  position =
-                    module.is.vertical()
-                    ?
-                    module.is.reversed() ? 'bottom' : 'top'
-                    :
-                    module.is.reversed() ? 'right' : 'left'
+                  $label = $('<li class="label">' + module.get.label(i) + '</li>'),
+                  ratio  = i / (len + 1)
                 ;
-                $label.css(position, module.determine.positionFromValue((i+1) * module.get.step() + module.get.min()));
+                module.update.labelPosition(ratio, $label);
                 $labels.append($label);
               }
             }
@@ -494,6 +483,24 @@ $.fn.slider = function(parameters) {
           },
           trackEndPos: function() {
             return module.is.reversed() ? module.get.trackLeft() : module.get.trackLeft() + module.get.trackLength();
+          },
+          trackStartMargin: function () {
+            var margin;
+            if (module.is.vertical()) {
+              margin = module.is.reversed() ? $module.css('padding-bottom') : $module.css('padding-top');
+            } else {
+              margin = module.is.reversed() ? $module.css('padding-right') : $module.css('padding-left');
+            }
+            return margin || '0px';
+          },
+          trackEndMargin: function () {
+            var margin;
+            if (module.is.vertical()) {
+              margin = module.is.reversed() ? $module.css('padding-top') : $module.css('padding-bottom');
+            } else {
+              margin = module.is.reversed() ? $module.css('padding-left') : $module.css('padding-right');
+            }
+            return margin || '0px';
           },
           precision: function() {
             var
@@ -852,6 +859,20 @@ $.fn.slider = function(parameters) {
             }
             module.debug('Setting range position to ' + newPos);
           },
+          labelPosition: function (ratio, $label) {
+            var
+              startMargin = module.get.trackStartMargin(),
+              endMargin   = module.get.trackEndMargin(),
+              posDir =
+                module.is.vertical()
+                ?
+                module.is.reversed() ? 'bottom' : 'top'
+                :
+                module.is.reversed() ? 'right' : 'left'
+            ;
+            var position = '(100% - ' + startMargin + ' - ' + endMargin + ') * ' + ratio;
+            $label.css(posDir, 'calc(' + position + ' + ' + startMargin + ')');
+          }
         },
 
         goto: {

--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -221,7 +221,7 @@ $.fn.slider = function(parameters) {
             if(module.get.step() != 0) {
               $labels = $module.find('.labels');
               if($labels.length != 0)
-                $labels.empty()
+                $labels.empty();
               else
                 $labels = $module.append('<ul class="auto labels"></ul>').find('.labels');
               for(var i = 0; i <= module.get.numLabels(); i++) {
@@ -566,7 +566,7 @@ $.fn.slider = function(parameters) {
                 return position;
               case 'second':
                 if(module.is.doubled())
-                  return secondThumbPosition;
+                  return secondPos;
                 else {
                   module.error(error.notdouble);
                   break;
@@ -659,7 +659,7 @@ $.fn.slider = function(parameters) {
             // Use precision to avoid ugly Javascript floating point rounding issues
             // (like 35 * .01 = 0.35000000000000003)
             difference = Math.round(difference * precision) / precision;
-            module.verbose('Cutting off additional decimal places')
+            module.verbose('Cutting off additional decimal places');
             return difference + module.get.min();
           },
           keyMovement: function(event) {
@@ -736,7 +736,7 @@ $.fn.slider = function(parameters) {
               module.thumbVal = first;
               module.secondThumbVal = second;
               position = module.handleNewValuePosition(module.thumbVal);
-              module.update.position(position, $thumb)
+              module.update.position(position, $thumb);
               secondPos = module.handleNewValuePosition(module.secondThumbVal);
               module.update.position(secondPos, $secondThumb);
               value = Math.abs(module.thumbVal - module.secondThumbVal);
@@ -1096,7 +1096,7 @@ $.fn.slider.settings = {
 
   selector: {
 
-  }
+  },
 
   className     : {
     reversed : 'reversed',

--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -103,7 +103,6 @@ $.fn.slider = function(parameters) {
           module.read.metadata();
           module.read.settings();
 
-          // module.observeChanges();
           module.instantiate();
           settings.onChange.call(element, value, module.thumbVal, module.secondThumbVal);
         },
@@ -122,35 +121,7 @@ $.fn.slider = function(parameters) {
           module.unbind.events();
           module.unbind.slidingEvents();
           $module.removeData(moduleNamespace);
-          // module.disconnect.sliderObserver();
           instance = undefined;
-        },
-
-        observeChanges: function() {
-          if('MutationObserver' in window) {
-            sliderObserver = new MutationObserver(module.event.resize);
-            module.debug('Setting up mutation observer', sliderObserver);
-            module.observe.slider();
-          }
-        },
-
-        observe: {
-          slider: function() {
-            sliderObserver.observe($module[0], {
-              attributes: true,
-              // It will be better if CSS style changes can be observed,
-              // see http://xml3d.org/xml3d/specification/styleobserver
-              attributeFilter: ['class', 'style']
-            });
-          },
-        },
-
-        disconnect: {
-          sliderObserver: function() {
-            if(sliderObserver) {
-              sliderObserver.disconnect();
-            }
-          }
         },
 
         setup: {
@@ -243,15 +214,11 @@ $.fn.slider = function(parameters) {
         bind: {
           events: function() {
             module.bind.globalKeyboardEvents();
-            // module.bind.resizeListener();
             module.bind.keyboardEvents();
             module.bind.mouseEvents();
             if(module.is.touch()) {
               module.bind.touchEvents();
             }
-          },
-          resizeListener: function() {
-            $(window).on('resize' + eventNamespace, module.event.resize);
           },
           keyboardEvents: function() {
             module.verbose('Binding keyboard events');
@@ -308,7 +275,6 @@ $.fn.slider = function(parameters) {
             $module.off('touchstart' + eventNamespace);
             $module.off('keydown' + eventNamespace);
             $module.off('focusout' + eventNamespace);
-            // $(window).off('resize' + eventNamespace);
             $(document).off('keydown' + eventNamespace + documentEventID, module.event.activateFocus);
           },
           slidingEvents: function() {
@@ -323,9 +289,6 @@ $.fn.slider = function(parameters) {
         },
 
         event: {
-          resize: function(event) {
-            module.resync();
-          },
           down: function(event, originalEvent) {
             event.preventDefault();
             if(module.is.doubled()) {

--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -207,7 +207,7 @@ $.fn.slider = function(parameters) {
             ;
             $children.each(function(index) {
               var
-                $child    = $(this),
+                $child = $(this),
                 attrValue = $child.attr('data-value')
               ;
               if(attrValue) {
@@ -228,10 +228,10 @@ $.fn.slider = function(parameters) {
               else {
                 $labels = $module.append('<ul class="auto labels"></ul>').find('.labels');
               }
-              for(var i = 1, len = module.get.numLabels(); i <= len; i++) {
+              for(var i = 1, len = module.get.numLabels(); i < len; i++) {
                 var
                   $label = $('<li class="label">' + module.get.label(i) + '</li>'),
-                  ratio  = i / (len + 1)
+                  ratio  = i / len
                 ;
                 module.update.labelPosition(ratio, $label);
                 $labels.append($label);
@@ -525,9 +525,9 @@ $.fn.slider = function(parameters) {
             return settings.step;
           },
           numLabels: function() {
-            var value = Math.round((module.get.max() - module.get.min()) / module.get.step()) - 2;
+            var value = Math.round((module.get.max() - module.get.min()) / module.get.step());
             module.debug('Determined that their should be ' + value + ' labels');
-            return value
+            return value;
           },
           labelType: function() {
             return settings.labelType;

--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -105,7 +105,7 @@ $.fn.slider = function(parameters) {
 
           // module.observeChanges();
           module.instantiate();
-          settings.onChange.call(element, value);
+          settings.onChange.call(element, value, module.thumbVal, module.secondThumbVal);
         },
 
         instantiate: function() {
@@ -340,10 +340,10 @@ $.fn.slider = function(parameters) {
             var value = module.determine.valueFromEvent(event, originalEvent);
             if(module.get.step() == 0 || settings.smooth) {
               module.update.position(value);
-              settings.onMove.call(element, value);
+              settings.onMove.call(element, value, module.thumbVal, module.secondThumbVal);
             } else {
-              module.update.value(value, function(value) {
-                settings.onMove.call(element, value);
+              module.update.value(value, function(value, thumbVal, secondThumbVal) {
+                settings.onMove.call(element, value, thumbVal, secondThumbVal);
               });
             }
           },
@@ -753,8 +753,8 @@ $.fn.slider = function(parameters) {
 
         set: {
           value: function(newValue) {
-            module.update.value(newValue, function(value) {
-              settings.onChange.call(element, value);
+            module.update.value(newValue, function(value, thumbVal, secondThumbVal) {
+              settings.onChange.call(element, value, thumbVal, secondThumbVal);
             });
           },
           valueDouble: function(first, second) {
@@ -764,7 +764,7 @@ $.fn.slider = function(parameters) {
               value = Math.abs(module.thumbVal - module.secondThumbVal);
               module.update.position(module.thumbVal, $thumb);
               module.update.position(module.secondThumbVal, $secondThumb);
-              settings.onChange.call(element, value);
+              settings.onChange.call(element, value, module.thumbVal, module.secondThumbVal);
             } else {
               module.error(error.notdouble);
             }
@@ -782,7 +782,7 @@ $.fn.slider = function(parameters) {
                 module.update.position(thumbVal, $thumb);
             }
             value = Math.abs(module.thumbVal - module.secondThumbVal);
-            settings.onChange.call(element, value);
+            settings.onChange.call(element, value, module.thumbVal, module.secondThumbVal);
           }
         },
 
@@ -812,7 +812,7 @@ $.fn.slider = function(parameters) {
             module.update.position(newValue);
             module.debug('Setting range value to ' + value);
             if(typeof callback === 'function') {
-              callback(value);
+              callback(value, module.thumbVal, module.secondThumbVal);
             }
           },
           position: function(newValue, $element) {
@@ -896,7 +896,7 @@ $.fn.slider = function(parameters) {
             var
               data = {
                 thumbVal        : $module.data(metadata.thumbVal),
-                secondThumbVal  : $module.data(metadata.secondThumbVal),
+                secondThumbVal  : $module.data(metadata.secondThumbVal)
               }
             ;
             if(data.thumbVal) {
@@ -1170,8 +1170,8 @@ $.fn.slider.settings = {
     letter  : 'letter'
   },
 
-  onChange : function(value){},
-  onMove   : function(value){},
+  onChange : function(value, thumbVal, secondThumbVal){},
+  onMove   : function(value, thumbVal, secondThumbVal){},
 };
 
 

--- a/src/definitions/modules/slider.js
+++ b/src/definitions/modules/slider.js
@@ -343,8 +343,19 @@ $.fn.slider = function(parameters) {
             event.preventDefault();
             var value = module.determine.valueFromEvent(event, originalEvent);
             if(module.get.step() == 0 || settings.smooth) {
-              module.update.position(value);
-              settings.onMove.call(element, value, module.thumbVal, module.secondThumbVal);
+              var
+                thumbVal = module.thumbVal,
+                secondThumbVal = module.secondThumbVal,
+                thumbSmoothVal = module.determine.smoothValueFromEvent(event, originalEvent)
+              ;
+              if(!$currThumb.hasClass('second')) {
+                thumbVal = value;
+              } else {
+                secondThumbVal = value;
+              }
+              value = Math.abs(thumbVal - (secondThumbVal || 0));
+              module.update.position(thumbSmoothVal);
+              settings.onMove.call(element, value, thumbVal, secondThumbVal);
             } else {
               module.update.value(value, function(value, thumbVal, secondThumbVal) {
                 settings.onMove.call(element, value, thumbVal, secondThumbVal);
@@ -658,6 +669,24 @@ $.fn.slider = function(parameters) {
             }
             return value;
           },
+          smoothValueFromEvent: function(event, originalEvent) {
+            var
+              min = module.get.min(),
+              max = module.get.max(),
+              trackLength = module.get.trackLength(),
+              eventPos = module.determine.eventPos(event, originalEvent),
+              newPos = eventPos - module.get.trackOffset(),
+              ratio,
+              value
+            ;
+            newPos = newPos < 0 ? 0 : newPos > trackLength ? trackLength : newPos;
+            ratio = newPos / trackLength;
+            if (module.is.reversed()) {
+              ratio = 1 - ratio;
+            }
+            value = ratio * (max - min) + min;
+            return value;
+          },
           eventPos: function(event, originalEvent) {
             if(module.is.touch()) {
               var
@@ -782,7 +811,7 @@ $.fn.slider = function(parameters) {
                 module.thumbVal = thumbVal;
                 module.update.position(thumbVal, $thumb);
             }
-            value = Math.abs(module.thumbVal - module.secondThumbVal);
+            value = Math.abs(module.thumbVal - (module.secondThumbVal || 0));
             settings.onChange.call(element, value, module.thumbVal, module.secondThumbVal);
           }
         },

--- a/src/definitions/modules/slider.less
+++ b/src/definitions/modules/slider.less
@@ -208,7 +208,7 @@
 }
 
 .ui.labeled.vertical.slider > .labels .label {
-  transform: translate(-100%, -50%); // translate(-100%, -@labelWidth);
+  transform: translate(-100%, -50%);
 }
 
 .ui.labeled.vertical.slider > .labels .label:after {

--- a/src/definitions/modules/slider.less
+++ b/src/definitions/modules/slider.less
@@ -208,7 +208,7 @@
 }
 
 .ui.labeled.vertical.slider > .labels .label {
-  transform: translate(-100%, -@labelWidth);
+  transform: translate(-100%, -50%); // translate(-100%, -@labelWidth);
 }
 
 .ui.labeled.vertical.slider > .labels .label:after {
@@ -216,6 +216,11 @@
   height: @labelWidth;
   left: 100%;
   top: 50%;
+}
+
+/* Vertical Reversed Labels */
+.ui.labeled.vertical.reversed.slider > .labels .label {
+  transform: translate(-100%, 50%);
 }
 
 /*--------------

--- a/src/definitions/modules/slider.less
+++ b/src/definitions/modules/slider.less
@@ -128,24 +128,24 @@
     Vertical
 ---------------*/
 
-.ui.vertical.slider{
+.ui.vertical.slider {
   height: 100%;
   padding: @verticalPadding;
 }
 
-.ui.vertical.slider.inner {
+.ui.vertical.slider .inner {
   width: @height;
   height: 100%;
 }
 
-.ui.vertical.slider.inner .track {
+.ui.vertical.slider .inner .track {
   height: 100%;
   width: @trackHeight;
   left: @trackPositionTop;
   top: 0;
 }
 
-.ui.vertical.slider.inner .track-fill {
+.ui.vertical.slider .inner .track-fill {
   height: 0;
   width: @trackFillHeight;
   left: @trackPositionTop;

--- a/src/definitions/modules/slider.less
+++ b/src/definitions/modules/slider.less
@@ -169,11 +169,13 @@
 
 .ui.labeled.slider > .labels {
   height: @labelHeight;
-  width: 100%;
+  width: auto;
   margin: 0;
   padding: 0;
   position: absolute;
   top: 50%;
+  left: 0;
+  right: 0;
 }
 
 .ui.labeled.slider:not(.vertical) > .labels {
@@ -200,9 +202,10 @@
 
 .ui.labeled.vertical.slider > .labels {
   width: @labelHeight;
-  height: 100%;
+  height: auto;
   left: 50%;
   top: 0;
+  bottom: 0;
   transform: translateX(-50%);
 }
 

--- a/src/definitions/modules/slider.less
+++ b/src/definitions/modules/slider.less
@@ -53,7 +53,6 @@
 }
 
 .ui.slider:not(.vertical) .inner .track-fill {
-  width: 0;
   height: @trackFillHeight;
   top: @trackPositionTop;
   left: 0;
@@ -146,7 +145,6 @@
 }
 
 .ui.vertical.slider .inner .track-fill {
-  height: 0;
   width: @trackFillHeight;
   left: @trackPositionTop;
   top: 0;


### PR DESCRIPTION
There are following changes:
- Code cleaning and format;
- Add slider container padding when locating labels;
- Use css function `calc()` to locate thumb, track fill and labels, so no need to listen resize event or observe element changes;
- Extra parameter `thumbVal`, `secondThumbVal` for listener `onChange()` and `onMove()`;
- Exactly updating global variables `value`, `module.thumbVal`, `module.secondThumbVal`, `position` and `secondPos`;
- Set or update `value` to `min` or `max` when mouse is moving out slider;
