### PR TITLE
[Horizontal List] moved margin from left to right

### DIFF
--- a/src/definitions/elements/list.less
+++ b/src/definitions/elements/list.less
@@ -282,11 +282,13 @@ ol.ui.list ol li,
 }
 .ui.horizontal.list > .item {
   display: inline-block;
-  margin-left: @horizontalSpacing;
+  margin-right: @horizontalSpacing;
   font-size: 1rem;
 }
+.ui.horizontal.list:not(.celled) > .item:last-child {
+  margin-right: 0em !important;
+}
 .ui.horizontal.list:not(.celled) > .item:first-child {
-  margin-left: 0em !important;
   padding-left: 0em !important;
 }
 .ui.horizontal.list .list {
@@ -948,4 +950,3 @@ ol.ui.horizontal.list li:before,
 }
 
 .loadUIOverrides();
-


### PR DESCRIPTION
Fixes #4501

I didn't touch the padding-right as in https://github.com/Semantic-Org/Semantic-UI/pull/4502 - might be unrelated, or not relevant at all. I don't know.