### PR TITLE
Fix <body> being set to position relative when dimmable class applied

### DIFF
--- a/src/definitions/modules/dimmer.less
+++ b/src/definitions/modules/dimmer.less
@@ -21,7 +21,7 @@
             Dimmer
 *******************************/
 
-.dimmable:not(.body) {
+.dimmable:not(body) {
   position: @dimmablePosition;
 }
 


### PR DESCRIPTION
 Found body is being set to position:relative and cause some of our JS code function incorrectly for example drag and drop. The root cause seems to be this style. I assume there is a typo here.