### PR TITLE
[Segment] A basic segment within .segments should be basic

### DIFF
--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -463,7 +463,9 @@
        Basic
 --------------------*/
 
-.ui.basic.segment {
+.ui.basic.segment,
+.ui.segments .ui.basic.segment,
+.ui.basic.segments {
   background: @basicBackground;
   box-shadow: @basicBoxShadow;
   border: @basicBorder;


### PR DESCRIPTION
This PR try to fix a problem and add a new functionality :

- The fix : when we have a `.ui.basic.segment` inside of `.ui.horizontal.segments`, the basic segment doesn't loose the border and shadow.

- The new functionality : Add a `.ui.basic.segments` with **s**
It comes in handy when we want to do something like this
```css
.ui.horizontal.basic.segments>(.ui.basic.segment+.ui.basic.right.aligned.segment)
```