### PR TITLE
[Dropdown] Add "localsearch" Setting to allow local search when dropdown data retrieved from remote API

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -3504,7 +3504,7 @@ $.fn.dropdown.settings = {
 
 
   apiSettings            : false,
-  localSearch            : true,       // Whether trigger local search instead of querying data from remote source
+  localSearch            : false,      // Whether trigger local search instead of querying data from remote source
   selectOnKeydown        : true,       // Whether selection should occur automatically when keyboard shortcuts used
   minCharacters          : 0,          // Minimum characters required to trigger API call
   saveRemoteData         : true,       // Whether remote name/value pairs should be stored in sessionStorage to allow remote data to be restored on page refresh

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -702,6 +702,9 @@ $.fn.dropdown = function(parameters) {
           if(settings.apiSettings) {
             if( module.can.useAPI() ) {
               module.queryRemote(searchTerm, function() {
+                if (settings.localSearch) {
+                  module.filterItems(searchTerm);
+                }
                 afterFiltered();
               });
             }
@@ -3501,6 +3504,7 @@ $.fn.dropdown.settings = {
 
 
   apiSettings            : false,
+  localSearch            : true,       // Whether trigger local search instead of querying data from remote source
   selectOnKeydown        : true,       // Whether selection should occur automatically when keyboard shortcuts used
   minCharacters          : 0,          // Minimum characters required to trigger API call
   saveRemoteData         : true,       // Whether remote name/value pairs should be stored in sessionStorage to allow remote data to be restored on page refresh


### PR DESCRIPTION
Dropdown local search only happened with local data, and dropdown with remote api will search the data by continuous invoking API with query parameter. 

Since for some scenarios, we just want to retrieve the data once from the server, and search the data locally. To support this requirement, I have enhanced the dropdown module to support local search when data is retrieved from remote API.

`localSearch` is default to `false`, so it will not effect the existing features of dropdown widget. If the user needs to enable local search with remote API data, then simply set the `localSearch` setting to `true` as follow:

```
$modelDropdown.dropdown({
  apiSettings: {
    url: '/api/data.json'
  },
  fields: {
    name  : 'name', // displayed dropdown    
    value : 'id'         // actual dropdown value
  },
  localSearch: true,  // explicitly enable local search when needed
});
```