### PR TITLE
[Dropdown] #4896 Fix for triangle position

### DIFF
--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -1346,6 +1346,33 @@ select.ui.dropdown {
   box-shadow: @pointingUpwardArrowBoxShadow;
   margin: @pointingArrowOffset 0em 0em;
 }
+/* ... (only for icon) */
+.ui.icon.upward.pointing.dropdown:not(.top) > .menu {
+  bottom: 0%;
+}
+.ui.icon.upward.pointing.dropdown:not(.top) > .menu:after {
+  top: ~"calc(100% - 1em)";
+}
+
+/* Upward Left (non-Top) (only for icon, link) */
+.ui.link.upward.left.pointing.dropdown > .menu:after {
+  top: ~"calc(100% - 1em)";
+  transform: rotate(135deg);
+}
+.ui.icon.upward.left.pointing.dropdown:not(.top) > .menu {
+  margin: 0em 0em 0em @pointingArrowDistanceFromEdge;
+}
+.ui.icon.upward.left.pointing.dropdown:not(.top) > .menu:after {
+  transform: rotate(135deg);
+}
+
+/* Upward Right (non-Top) (only for icon) */
+.ui.icon.upward.right.pointing.dropdown:not(.top) > .menu {
+  margin: 0em @pointingArrowDistanceFromEdge 0em 0em;
+}
+.ui.icon.upward.right.pointing.dropdown:not(.top) > .menu:after {
+  transform: rotate(-45deg);
+}
 
 
 .loadUIOverrides();


### PR DESCRIPTION
It's possible to see a problem in [#4896](https://github.com/Semantic-Org/Semantic-UI/issues/4896) request. This PR fixes wrong position and direction of triangle of dropdown for icons and links, also it fixes wrong (I'm not sure about that) position of dropdown (I believe you'll understand what a problem I'm talking about, when you see screenshot below)
![example](https://cloud.githubusercontent.com/assets/8342564/22164270/979a27fe-df67-11e6-8901-2720d22b50f2.png)

