### PR TITLE
[Table] Top border should be visible in first nested table

### DIFF
--- a/src/definitions/collections/table.less
+++ b/src/definitions/collections/table.less
@@ -118,7 +118,7 @@
 .ui.table tr td {
   border-top: @rowBorder;
 }
-.ui.table tr:first-child td {
+.ui.table tr:first-child > td {
   border-top: none;
 }
 


### PR DESCRIPTION
When you nest another table inside a .ui.table, the top borders are also removed from every row inside the first nested table.

This can be fixed by applying the `border-top: none` only to the first direct descendant of .ui.table. I briefly tried to look for a scenario where this restriction might not be preferrable, but I couldn't find one..

See example of the issue below: first nested table lacks top borders, where all subsequent ones do have them.

<img width="783" alt="sui-nested-table-borders" src="https://cloud.githubusercontent.com/assets/5436121/22173975/c3dcaa80-e00c-11e6-8304-ca0de8a3aa7e.png">

