### PR TITLE
Fix for [Modal] Prevent modal actions buttons from clicking twice #4479

### DIFF
--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -234,7 +234,6 @@ $.fn.modal = function(parameters) {
               module.verbose('Approve callback returned false cancelling hide');
               return;
             }
-
             module.hide();
           },
           deny: function() {

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -209,7 +209,11 @@ $.fn.modal = function(parameters) {
             module.verbose('Attaching events');
             $module
               .on('click' + eventNamespace, selector.close, module.event.close)
-              .on('click' + eventNamespace, selector.approve, module.event.approve)
+              .on('click' + eventNamespace, selector.approve, function() {
+                if( !module.is.animating() ) {
+                  module.event.approve();
+                }
+              })
               .on('click' + eventNamespace, selector.deny, module.event.deny)
             ;
             $window
@@ -230,6 +234,7 @@ $.fn.modal = function(parameters) {
               module.verbose('Approve callback returned false cancelling hide');
               return;
             }
+
             module.hide();
           },
           deny: function() {
@@ -302,8 +307,11 @@ $.fn.modal = function(parameters) {
             ? callback
             : function(){}
           ;
-          module.refreshModals();
-          module.showModal(callback);
+
+          if( !module.is.active() && !module.is.animating() ) {
+            module.refreshModals();
+            module.showModal(callback);
+          }
         },
 
         hide: function(callback) {


### PR DESCRIPTION
Problem is described here: #4479

Adds a check for whether the modal is animating before firing the approve event. (Line 212)

Additionally adds a check for the `show` function in order to ensure that the modal is not animating and is not active before allowing it to be shown again. (Line 311)