### PR TITLE
Fix for #3476 Placeholder in IE11 looks Bolder

### DIFF
--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -319,44 +319,44 @@
 ---------------------*/
 
 /* browsers require these rules separate */
-.ui.form ::-webkit-input-placeholder {
+.ui.form input::-webkit-input-placeholder {
   color: @inputPlaceholderColor;
 }
-.ui.form :-ms-input-placeholder {
+.ui.form input:-ms-input-placeholder {
   color: @inputPlaceholderColor;
 }
-.ui.form ::-moz-placeholder {
+.ui.form input::-moz-placeholder {
   color: @inputPlaceholderColor;
 }
 
-.ui.form :focus::-webkit-input-placeholder {
+.ui.form input:focus::-webkit-input-placeholder {
   color: @inputPlaceholderFocusColor;
 }
-.ui.form :focus:-ms-input-placeholder {
+.ui.form input:focus:-ms-input-placeholder {
   color: @inputPlaceholderFocusColor;
 }
-.ui.form :focus::-moz-placeholder {
+.ui.form input:focus::-moz-placeholder {
   color: @inputPlaceholderFocusColor;
 }
 
 /* Error Placeholder */
-.ui.form .error ::-webkit-input-placeholder {
+.ui.form .error input::-webkit-input-placeholder {
   color: @inputErrorPlaceholderColor;
 }
-.ui.form .error :-ms-input-placeholder {
+.ui.form .error input:-ms-input-placeholder {
   color: @inputErrorPlaceholderColor !important;
 }
-.ui.form .error ::-moz-placeholder {
+.ui.form .error input::-moz-placeholder {
   color: @inputErrorPlaceholderColor;
 }
 
-.ui.form .error :focus::-webkit-input-placeholder {
+.ui.form .error input:focus::-webkit-input-placeholder {
   color: @inputErrorPlaceholderFocusColor;
 }
-.ui.form .error :focus:-ms-input-placeholder {
+.ui.form .error input:focus:-ms-input-placeholder {
   color: @inputErrorPlaceholderFocusColor !important;
 }
-.ui.form .error :focus::-moz-placeholder {
+.ui.form .error input:focus::-moz-placeholder {
   color: @inputErrorPlaceholderFocusColor;
 }
 


### PR DESCRIPTION
Without the `input` selector in front of the pseudo selectors, the formatting had no effect on Internet Explorer 11 input placeholders.

The problem was only present in the UI Form formatting (and not the UI Input formatting).