### PR TITLE
Add field bottom margin on largest mobile screen.

### DIFF
--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -934,6 +934,7 @@
   .ui.form .fields > .fifteen.wide.field,
   .ui.form .fields > .sixteen.wide.field {
     width: @oneColumn !important;
+    margin: 0em 0em @rowDistance;
   }
   .ui.form .fields {
     margin-bottom: 0em;


### PR DESCRIPTION
I don't know if it's intentional, there's no bottom margin if `field` has not `equal width`.