### PR TITLE
Added main key

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "homepage": "http://www.semantic-ui.com",
   "author": "Jack Lukic <jack@semantic-ui.com>",
   "license": "MIT",
+  "main": "dist/semantic.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/Semantic-Org/Semantic-UI.git"


### PR DESCRIPTION
This key should be existed in order to make the package easily require the package by name like,

window.semantic = require('semantic-ui')