### PR TITLE
[Modal] #5053 Focus trapping inside the modal

### DIFF
--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -726,8 +726,15 @@ $.fn.modal = function(parameters) {
 
         set: {
           autofocus: function() {
-            if (module.cache.firstFocusElement) {
-              module.cache.firstFocusElement.focus();
+            var
+              $inputs    = $module.find('[tabindex], :input').filter(':visible'),
+              $autofocus = $inputs.filter('[autofocus]'),
+              $input     = ($autofocus.length > 0)
+                ? $autofocus.first()
+                : $(module.cache.firstFocusElement)
+            ;
+            if($input.length > 0) {
+              $input.focus();
             }
           },
           clickaway: function() {

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -791,12 +791,6 @@ $.fn.modal = function(parameters) {
           }
         },
 
-        manage: {
-            focus: function() {
-                
-            }
-        },
-
         setting: function(name, value) {
           module.debug('Changing setting', name, value);
           if( $.isPlainObject(name) ) {

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -173,7 +173,8 @@ $.fn.modal = function(parameters) {
 
         refresh: function() {
           module.remove.scrolling();
-          module.cacheSizes();
+          module.cache.sizes();
+          module.cache.tabNavigable();
           module.set.screenHeight();
           module.set.type();
           module.set.position();
@@ -221,6 +222,48 @@ $.fn.modal = function(parameters) {
         get: {
           id: function() {
             return (Math.random().toString(16) + '000000000').substr(2,8);
+          },
+          tabIndex: function(element) {
+            var 
+              $element   = (typeof element === 'undefined') ? $module : $(element),
+              isTabbable = false,
+              iframeBody
+            ;
+            element = $element.get(0);
+            
+            if($element.is(':disabled')) {
+              return undefined;
+            } else if($element.is('[tabIndex]')) {
+              return $element.attr('tabIndex');
+            } else {
+              switch (element.nodeName.toLowerCase()) {
+                case 'a':
+                  isTabbable = $element.is('[href]');
+                  break;
+                case 'area':
+                case 'button':
+                case 'input':
+                case 'object':
+                case 'select':
+                case 'textarea':
+                  isTabbable = true;
+                  break;
+                case 'iframe':
+                  try {
+                    if(element.contentDocument && 'designMode' in element.contentDocument && element.contentDocument.designMode == 'on') {
+                      isTabbable = true;
+                      break;
+                    }
+                    iframeBody = element.contentDocument.body || element.contentWindow.document.body;
+                  } catch(e) {
+                    break;
+                  }
+                  isTabbable = iframeBody && (iframeBody.contentEditable == 'true' || (iframeBody.firstChild && iframeBody.firstChild.contentEditable == 'true') );
+                default:
+                  isTabbable = (element.contentEditable == 'true');
+              }
+              return (isTabbable) ? 0 : undefined;
+            }
           }
         },
 
@@ -265,7 +308,33 @@ $.fn.modal = function(parameters) {
             clearTimeout(module.timer);
             module.timer = setTimeout(method, delay);
           },
-          keyboard: function(event) {
+          keyboardDown: function(event) {
+            var
+              keyCode   = event.which,
+              tabKey    = 9,
+              target    = event.target
+            ;
+            if(keyCode == tabKey) {
+              if(module.cache.firstFocusElement == module.cache.lastFocusElement) {
+                module.debug('Only one focusable element; tab does nothing');
+                event.stopPropagation();
+                event.preventDefault();
+              }
+              else if(target == module.cache.firstFocusElement && event.shiftKey) {
+                module.debug('Tabbing past the first element; last element is focused');
+                module.cache.lastFocusElement.focus();
+                event.stopPropagation();
+                event.preventDefault();
+              }
+              else if(target == module.cache.lastFocusElement && !event.shiftKey) {
+                module.debug('Tabbing past the last element; first element is focused');
+                module.cache.firstFocusElement.focus();
+                event.stopPropagation();
+                event.preventDefault();
+              }
+            }
+          },
+          keyboardUp: function(event) {
             var
               keyCode   = event.which,
               escapeKey = 27
@@ -323,7 +392,7 @@ $.fn.modal = function(parameters) {
           if( module.is.animating() || !module.is.active() ) {
 
             module.showDimmer();
-            module.cacheSizes();
+            module.cache.sizes();
             module.set.position();
             module.set.screenHeight();
             module.set.type();
@@ -349,6 +418,7 @@ $.fn.modal = function(parameters) {
                         module.add.keyboardShortcuts();
                       }
                       module.save.focus();
+                      module.cache.tabNavigable();
                       module.set.active();
                       if(settings.autofocus) {
                         module.set.autofocus();
@@ -481,7 +551,8 @@ $.fn.modal = function(parameters) {
           keyboardShortcuts: function() {
             module.verbose('Adding keyboard shortcuts');
             $document
-              .on('keyup' + eventNamespace, module.event.keyboard)
+              .on('keydown' + eventNamespace, module.event.keyboardDown)
+              .on('keyup' + eventNamespace, module.event.keyboardUp)
             ;
           }
         },
@@ -535,20 +606,97 @@ $.fn.modal = function(parameters) {
           }
         },
 
-        cacheSizes: function() {
-          var
-            modalHeight = $module.outerHeight()
-          ;
-          if(module.cache === undefined || modalHeight !== 0) {
-            module.cache = {
-              pageHeight    : $(document).outerHeight(),
-              height        : modalHeight + settings.offset,
-              contextHeight : (settings.context == 'body')
+        cache: {
+          sizes: function() {
+            var
+              modalHeight = $module.outerHeight()
+            ;
+            if(module.cache === undefined) module.cache = {};
+            if(!module.cache.pageHeight || modalHeight !== 0) {
+              module.cache.pageHeight = $(document).outerHeight();
+              module.cache.height = modalHeight + settings.offset;
+              module.cache.contextHeight = (settings.context == 'body')
                 ? $(window).height()
                 : $dimmable.height()
+            }
+            module.debug('Caching modal and container sizes', module.cache);
+          },
+          tabNavigable: function() {
+            var
+              radioSelected = {},
+              first,
+              last,
+              lowest,
+              lowestTabIndex,
+              highest,
+              highestTabIndex
+            ;
+            
+            var getRadioName = function(node) {
+              return node && node.tagName.toLowerCase() == "input" &&
+                node.type && node.type.toLowerCase() == "radio" &&
+                node.name && node.name.toLowerCase();
             };
+            
+            var radioSubstitution = function(node) {
+              return radioSelected[getRadioName(node)] || node;
+            };
+
+            var walkTree = function(parent) {
+              var
+                child    = parent.firstChild,
+                $child,
+                tabIndex,
+                radioName
+              ;
+              while(child) {
+                $child = $(child);
+                if(child.nodeType != 1 || !$child.is(':visible')) {
+                  child = child.nextSibling;
+                  continue;
+                }
+                
+                tabIndex = module.get.tabIndex(child);
+                if(tabIndex >= 0) {
+                  if(tabIndex == 0) {
+                    if(!first) {
+                      first = child;
+                    }
+                    last = child;
+                  }
+                  else {
+                    if(!lowest || tabIndex < lowestTabIndex) {
+                      lowestTabIndex = tabIndex;
+                      lowest = child;
+                    }
+                    if(!highest || tabIndex >= highestTabIndex) {
+                      highestTabIndex = tabIndex;
+                      highest = child;
+                    }
+                  }
+                }
+                
+                radioName = getRadioName(child);
+                if($child.is(':checked') && radioName) {
+                  radioSelected[radioName] = child;
+                }
+                
+                if(child.nodeName.toLowerCase() != 'select'){
+                  walkTree(child);
+                }
+                
+                child = child.nextSibling;
+              }
+            };
+            
+            if($module.is(':visible')) {
+              walkTree($module.get(0));
+            }
+            
+            if(module.cache === undefined) module.cache = {};
+            module.cache.firstFocusElement = radioSubstitution(lowest) || radioSubstitution(first);
+            module.cache.lastFocusElement = radioSubstitution(last) || radioSubstitution(highest) || module.cache.firstFocusElement;
           }
-          module.debug('Caching modal and container sizes', module.cache);
         },
 
         can: {
@@ -578,15 +726,8 @@ $.fn.modal = function(parameters) {
 
         set: {
           autofocus: function() {
-            var
-              $inputs    = $module.find('[tabindex], :input').filter(':visible'),
-              $autofocus = $inputs.filter('[autofocus]'),
-              $input     = ($autofocus.length > 0)
-                ? $autofocus.first()
-                : $inputs.first()
-            ;
-            if($input.length > 0) {
-              $input.focus();
+            if (module.cache.firstFocusElement) {
+              module.cache.firstFocusElement.focus();
             }
           },
           clickaway: function() {
@@ -648,6 +789,12 @@ $.fn.modal = function(parameters) {
           undetached: function() {
             $dimmable.addClass(className.undetached);
           }
+        },
+
+        manage: {
+            focus: function() {
+                
+            }
         },
 
         setting: function(name, value) {


### PR DESCRIPTION
This code is ready for review.

From issue #5053, implements focus trapping inside of the modal. Tabbing from the last focusable element will move to the first inside the modal, and vice a versa.

Complies with ARIA accessibility guidelines.
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_dialog_role