### PR TITLE
Removed incorrect default answer for the useRoot question, fixes #4941

### DIFF
--- a/tasks/install.js
+++ b/tasks/install.js
@@ -174,7 +174,6 @@ if(manager.name == 'NPM') {
     .replace('{root}', manager.root)
   ;
   // set default path to detected PM root
-  rootQuestions[0].default = manager.root;
   rootQuestions[1].default = manager.root;
 
   // insert PM questions after "Install Type" question


### PR DESCRIPTION
To test this PR:
- Making sure your local version of semantic-ui is inside a node_modules directory, run `gulp install`.
- Choose *Automatic* when prompted for the Set-up of Semantic UI.
- When prompted for the project folder, the first option should be selected by default - it wasn't previously and that's what was causing the issue, see https://github.com/SBoudrias/Inquirer.js/issues/203.

This fixes #4941.