### PR TITLE
[Dropdown] The width of inputs that are inside of a dropdown’s `.menu` should never be overridden

### DIFF
--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -182,7 +182,7 @@
 }
 
 .ui.dropdown .menu > .input {
-  width: auto;
+  width: auto !important;
   display: flex;
   margin: @menuInputMargin;
   min-width: @menuInputMinWidth;

--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -181,8 +181,8 @@
   margin: @menuDividerMargin;
 }
 
-.ui.dropdown .menu > .input {
-  width: auto !important;
+.ui.dropdown.dropdown .menu > .input {
+  width: auto;
   display: flex;
   margin: @menuInputMargin;
   min-width: @menuInputMinWidth;


### PR DESCRIPTION
Resolves #5085.