### PR TITLE
Addresses Issue #2358 for build-docs task

### DIFF
--- a/tasks/docs/build.js
+++ b/tasks/docs/build.js
@@ -162,7 +162,7 @@ module.exports = function(callback) {
   ;
 
   // copy assets
-  gulp.src(source.themes + '/**/assets/**/' + globs.components + '?(s).*')
+  gulp.src(source.themes + '/**/assets/**/*.*')
     .pipe(gulpif(config.hasPermission, chmod(config.permission)))
     .pipe(gulp.dest(output.themes))
   ;


### PR DESCRIPTION
Copy all assets into dist/themes folder when building the docs