### PR TITLE
More flexible creditCard validation

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1520,6 +1520,8 @@ $.fn.form.settings = {
         return;
       }
 
+      cardNumber = cardNumber.replace(/[^0-9.]/g, '');
+
       // verify card types
       if(requiredTypes) {
         $.each(requiredTypes, function(index, type){


### PR DESCRIPTION
You've done a spectacular job of credit card validation.
But the code forces unnecessary conditions: 
1) Users must enter credit cards without dashes
2) UX improvements which allow user-friendly credit card entry are by design invalid (such as [js formatter](https://github.com/mypebble/formatter.js) ... demo [here](http://firstopinion.github.io/formatter.js/demos.html))

I've added one line of code to strip non-numerics before validation, returning control to the developer.