### PR TITLE
Dropdown text’s error state shouldn’t be applied to menu items that have descriptions

### DIFF
--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -520,7 +520,7 @@
 .ui.form .fields.error .field .ui.dropdown,
 .ui.form .fields.error .field .ui.dropdown .item,
 .ui.form .field.error .ui.dropdown,
-.ui.form .field.error .ui.dropdown .text,
+.ui.form .field.error .ui.dropdown > .text,
 .ui.form .field.error .ui.dropdown .item {
   background: @formErrorBackground;
   color: @formErrorColor;


### PR DESCRIPTION
Resolves #5207.

Before:
![sui_before](https://cloud.githubusercontent.com/assets/6409354/24435004/7b4940cc-143b-11e7-9879-e6ca9825f0a0.PNG)

After:
![sui_after](https://cloud.githubusercontent.com/assets/6409354/24435010/83b5a11a-143b-11e7-967c-f3605ae9fde3.PNG)
