### PR TITLE
Feature/scroll modal content

### DIFF
--- a/examples/modals.html
+++ b/examples/modals.html
@@ -1,0 +1,301 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <!-- Standard Meta -->
+  <meta charset="utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+
+  <!-- Site Properties -->
+  <title>Modals - Semantic</title>
+  <link rel="stylesheet" type="text/css" href="../dist/semantic.css">
+
+
+  <style type="text/css">
+
+  </style>
+  <script
+      src="https://code.jquery.com/jquery-3.1.1.min.js"
+      integrity="sha256-hVVnYaiADRTO2PzUGmuLJr8BLUSjGIZsDYGmIJLv2b8="
+      crossorigin="anonymous"></script>
+  <script src="../dist/semantic.js"></script>
+</head>
+<body>
+
+<div class="ui segment">
+
+     <h2 class="ui header">Modals</h2>
+
+    <div class="ui modal" id="normalModal">
+      <i class="close icon"></i>
+      <div class="header">
+        Profile Picture
+      </div>
+      <div class="image content">
+        <div class="ui medium image">
+         <img src="assets\images\avatar\nan.jpg">
+        </div>
+        <div class="description">
+          <div class="ui header">We've auto-chosen a profile image for you.</div>
+          <p>We've grabbed the following image from the <a href="https://www.gravatar.com" target="_blank">gravatar</a> image associated with your registered e-mail address.</p>
+          <p>Is it okay to use this photo?</p>
+        </div>
+      </div>
+      <div class="actions">
+        <div class="ui black deny button">
+          Nope
+        </div>
+        <div class="ui positive right labeled icon button">
+          Yep, that's me
+          <i class="checkmark icon"></i>
+        </div>
+      </div>
+    </div>
+
+    <button  class="ui button" id="showNormalModal">Normal Modal</button>
+
+
+    <div class="ui basic modal" id="basicModal">
+      <div class="ui icon header">
+        <i class="archive icon"></i>
+        Archive Old Messages
+      </div>
+      <div class="content">
+        <p>Your inbox is getting full, would you like us to enable automatic archiving of old messages?</p>
+      </div>
+      <div class="actions">
+        <div class="ui red basic cancel inverted button">
+          <i class="remove icon"></i>
+          No
+        </div>
+        <div class="ui green ok inverted button">
+          <i class="checkmark icon"></i>
+          Yes
+        </div>
+      </div>
+    </div>
+
+    <button class="ui button" id="showBasicModal">Basic Modal</button>
+
+
+    <div class="ui modal" id="longModal">
+      <i class="close icon"></i>
+      <div class="header">
+        Profile Picture
+      </div>
+      <div class="image content">
+        <div class="ui medium image">
+          <img src="assets\images\avatar\nan.jpg">
+        </div>
+        <div class="description">
+          <div class="ui header">We've auto-chosen a profile image for you.</div>
+          <p>We've grabbed the following image from the <a href="https://www.gravatar.com" target="_blank">gravatar</a> image associated with your registered e-mail address.</p>
+          <p>Is it okay to use this photo?</p>
+          <button class="ui button">Some action</button>
+
+           <div class="ui header">We've auto-chosen a profile image for you.</div>
+          <p>We've grabbed the following image from the <a href="https://www.gravatar.com" target="_blank">gravatar</a> image associated with your registered e-mail address.</p>
+          <p>Is it okay to use this photo?</p>
+          <button class="ui button">Some action</button>
+
+
+           <div class="ui header">We've auto-chosen a profile image for you.</div>
+          <p>We've grabbed the following image from the <a href="https://www.gravatar.com" target="_blank">gravatar</a> image associated with your registered e-mail address.</p>
+          <p>Is it okay to use this photo?</p>
+          <button class="ui button">Some action</button>
+
+
+           <div class="ui header">We've auto-chosen a profile image for you.</div>
+          <p>We've grabbed the following image from the <a href="https://www.gravatar.com" target="_blank">gravatar</a> image associated with your registered e-mail address.</p>
+          <p>Is it okay to use this photo?</p>
+          <button class="ui button">Some action</button>
+
+
+           <div class="ui header">We've auto-chosen a profile image for you.</div>
+          <p>We've grabbed the following image from the <a href="https://www.gravatar.com" target="_blank">gravatar</a> image associated with your registered e-mail address.</p>
+          <p>Is it okay to use this photo?</p>
+          <button class="ui button">Some action</button>
+
+
+           <div class="ui header">We've auto-chosen a profile image for you.</div>
+          <p>We've grabbed the following image from the <a href="https://www.gravatar.com" target="_blank">gravatar</a> image associated with your registered e-mail address.</p>
+          <p>Is it okay to use this photo?</p>
+          <button class="ui button">Some action</button>
+
+
+           <div class="ui header">We've auto-chosen a profile image for you.</div>
+          <p>We've grabbed the following image from the <a href="https://www.gravatar.com" target="_blank">gravatar</a> image associated with your registered e-mail address.</p>
+          <p>Is it okay to use this photo?</p>
+          <button class="ui button">Some action</button>
+
+
+           <div class="ui header">We've auto-chosen a profile image for you.</div>
+          <p>We've grabbed the following image from the <a href="https://www.gravatar.com" target="_blank">gravatar</a> image associated with your registered e-mail address.</p>
+          <p>Is it okay to use this photo?</p>
+          <button class="ui button">Some action</button>
+
+
+           <div class="ui header">We've auto-chosen a profile image for you.</div>
+          <p>We've grabbed the following image from the <a href="https://www.gravatar.com" target="_blank">gravatar</a> image associated with your registered e-mail address.</p>
+          <p>Is it okay to use this photo?</p>
+          <button class="ui button">Some action</button>
+
+           <div class="ui header">We've auto-chosen a profile image for you.</div>
+          <p>We've grabbed the following image from the <a href="https://www.gravatar.com" target="_blank">gravatar</a> image associated with your registered e-mail address.</p>
+          <p>Is it okay to use this photo?</p>
+          <button class="ui button">Some action</button>
+        </div>
+      </div>
+      <div class="actions">
+        <div class="ui black deny button">
+          Nope
+        </div>
+        <div class="ui positive right labeled icon button">
+          Yep, that's me
+          <i class="checkmark icon"></i>
+        </div>
+      </div>
+    </div>
+
+    <button  class="ui button" id="showLongModal">Long Modal</button>
+
+ <div class="ui modal" id="longContentScrollModal">
+      <i class="close icon"></i>
+      <div class="header">
+        Profile Picture
+      </div>
+      <div class="image content scrollable">
+        <div class="ui medium image">
+          <img src="assets\images\avatar\nan.jpg">
+        </div>
+        <div class="description">
+          <div class="ui header">We've auto-chosen a profile image for you.</div>
+          <p>We've grabbed the following image from the <a href="https://www.gravatar.com" target="_blank">gravatar</a> image associated with your registered e-mail address.</p>
+          <p>Is it okay to use this photo?</p>
+          <button class="ui button">Some action</button>
+
+           <div class="ui header">We've auto-chosen a profile image for you.</div>
+          <p>We've grabbed the following image from the <a href="https://www.gravatar.com" target="_blank">gravatar</a> image associated with your registered e-mail address.</p>
+          <p>Is it okay to use this photo?</p>
+          <button class="ui button">Some action</button>
+
+
+           <div class="ui header">We've auto-chosen a profile image for you.</div>
+          <p>We've grabbed the following image from the <a href="https://www.gravatar.com" target="_blank">gravatar</a> image associated with your registered e-mail address.</p>
+          <p>Is it okay to use this photo?</p>
+          <button class="ui button">Some action</button>
+
+
+           <div class="ui header">We've auto-chosen a profile image for you.</div>
+          <p>We've grabbed the following image from the <a href="https://www.gravatar.com" target="_blank">gravatar</a> image associated with your registered e-mail address.</p>
+          <p>Is it okay to use this photo?</p>
+          <button class="ui button">Some action</button>
+
+
+           <div class="ui header">We've auto-chosen a profile image for you.</div>
+          <p>We've grabbed the following image from the <a href="https://www.gravatar.com" target="_blank">gravatar</a> image associated with your registered e-mail address.</p>
+          <p>Is it okay to use this photo?</p>
+          <button class="ui button">Some action</button>
+
+
+           <div class="ui header">We've auto-chosen a profile image for you.</div>
+          <p>We've grabbed the following image from the <a href="https://www.gravatar.com" target="_blank">gravatar</a> image associated with your registered e-mail address.</p>
+          <p>Is it okay to use this photo?</p>
+          <button class="ui button">Some action</button>
+
+
+           <div class="ui header">We've auto-chosen a profile image for you.</div>
+          <p>We've grabbed the following image from the <a href="https://www.gravatar.com" target="_blank">gravatar</a> image associated with your registered e-mail address.</p>
+          <p>Is it okay to use this photo?</p>
+          <button class="ui button">Some action</button>
+
+
+           <div class="ui header">We've auto-chosen a profile image for you.</div>
+          <p>We've grabbed the following image from the <a href="https://www.gravatar.com" target="_blank">gravatar</a> image associated with your registered e-mail address.</p>
+          <p>Is it okay to use this photo?</p>
+          <button class="ui button">Some action</button>
+
+
+           <div class="ui header">We've auto-chosen a profile image for you.</div>
+          <p>We've grabbed the following image from the <a href="https://www.gravatar.com" target="_blank">gravatar</a> image associated with your registered e-mail address.</p>
+          <p>Is it okay to use this photo?</p>
+          <button class="ui button">Some action</button>
+
+           <div class="ui header">We've auto-chosen a profile image for you.</div>
+          <p>We've grabbed the following image from the <a href="https://www.gravatar.com" target="_blank">gravatar</a> image associated with your registered e-mail address.</p>
+          <p>Is it okay to use this photo?</p>
+          <button class="ui button">Some action</button>
+        </div>
+      </div>
+      <div class="actions">
+        <div class="ui black deny button">
+          Nope
+        </div>
+        <div class="ui positive right labeled big icon button">
+          Yep, that's me
+          <i class="checkmark icon"></i>
+        </div>
+      </div>
+    </div>
+
+    <button  class="ui button" id="showLongContentScrollModal">Long Modal (with conent scrolling)</button>
+  <div class="ui modal" id="shortContentScrollModal">
+      <i class="close icon"></i>
+      <div class="header">
+        Profile Picture
+      </div>
+      <div class="image content scrollable">
+        <div class="ui medium image">
+         <img src="assets\images\avatar\nan.jpg">
+        </div>
+        <div class="description">
+          <div class="ui header">We've auto-chosen a profile image for you.</div>
+          <p>We've grabbed the following image from the <a href="https://www.gravatar.com" target="_blank">gravatar</a> image associated with your registered e-mail address.</p>
+          <p>Is it okay to use this photo?</p>
+        </div>
+      </div>
+      <div class="actions">
+        <div class="ui black deny button">
+          Nope
+        </div>
+        <div class="ui positive right labeled icon button">
+          Yep, that's me
+          <i class="checkmark icon"></i>
+        </div>
+      </div>
+    </div>
+
+    <button  class="ui button" id="showShortContentScrollModal">Short Modal (with conent scrolling)</button>
+
+</div>
+<script language="javascript">
+$(document).ready(function(){
+    var basicBtn = $("#showBasicModal");
+    basicBtn.click(function(){
+        $('#basicModal').modal('show');
+    });
+
+     var basicBtn = $("#showNormalModal");
+    basicBtn.click(function(){
+        $('#normalModal').modal('show');
+    });
+
+    var basicBtn = $("#showLongModal");
+    basicBtn.click(function(){
+        $('#longModal').modal('show');
+    });
+
+     var basicBtn = $("#showLongContentScrollModal");
+    basicBtn.click(function(){
+        $('#longContentScrollModal').modal('show');
+    });
+
+     var basicBtn = $("#showShortContentScrollModal");
+    basicBtn.click(function(){
+        $('#shortContentScrollModal').modal('show');
+    });
+});
+</script>
+</body>
+
+</html>

--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -63,9 +63,9 @@ $.fn.modal = function(parameters) {
         $context        = $(settings.context),
         $close          = $module.find(selector.close),
 
-        $header = $(this).find('.header'),
-        $actions = $(this).find('.actions'),
-        $scrollableContent = $(this).find('.scrollable.content'),
+        $header = $module.find(selector.header),
+        $actions = $module.find(selector.actions),
+        $scrollableContent = $module.find(selector.scrollableContent),
 
         $allModals,
         $otherModals,
@@ -927,7 +927,10 @@ $.fn.modal.settings = {
     close    : '> .close',
     approve  : '.actions .positive, .actions .approve, .actions .ok',
     deny     : '.actions .negative, .actions .deny, .actions .cancel',
-    modal    : '.ui.modal'
+    modal    : '.ui.modal',
+    scrollableContent : '.scrollable.content',
+    actions : '.actions',
+    header : '.header'
   },
   error : {
     dimmer    : 'UI Dimmer, a required component is not included in this page',

--- a/src/definitions/modules/modal.less
+++ b/src/definitions/modules/modal.less
@@ -112,6 +112,11 @@
   padding: @contentPadding;
   background: @contentBackground;
 }
+
+.ui.modal > .content.scrollable{
+    overflow-y: auto;
+}
+
 .ui.modal > .image.content {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
Implements feature discussed in https://github.com/Semantic-Org/Semantic-UI/issues/4335

Adds **scrollable** class to modal content which causes scrolling to happen only within the modal, while it always fits fully in the page. That way header and action buttons are always accessible and page body needs no modifications.

The approach is to set max-height attribute to the content itself and its overflow-y to auto. However, this brings the issue of calculating proper height, which must take into account the size of the other modal elements - header and buttons.

The main issue with this implementation is that neither actions, header or even content heights are not accessible before the modal is visible and therefore either predefined value must be used or visible resize is necessary after it's shown (I opted for the first one, especially even imprecise values give correct result).
Alternative would be to use flexbox for modal layout.

NOTE: As long as there is no **scrollable** class within the first level modal elements, no existing code should be affected.