### PR TITLE
Fixed dropdown menu’s border having incorrect color under the error state

### DIFF
--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -526,16 +526,9 @@
   color: @formErrorColor;
 }
 .ui.form .fields.error .field .ui.dropdown,
-.ui.form .field.error .ui.dropdown {
+.ui.form .field.error .ui.dropdown,
+.ui.form .field.error .ui.dropdown > .menu {
   border-color: @formErrorBorder !important;
-}
-.ui.form .fields.error .field .ui.dropdown:hover,
-.ui.form .field.error .ui.dropdown:hover {
-  border-color: @formErrorBorder !important;
-}
-.ui.form .fields.error .field .ui.dropdown:hover .menu,
-.ui.form .field.error .ui.dropdown:hover .menu {
-  border-color: @formErrorBorder;
 }
 .ui.form .fields.error .field .ui.multiple.selection.dropdown > .label,
 .ui.form .field.error .ui.multiple.selection.dropdown > .label {


### PR DESCRIPTION
Before, it was showing red border only on hover, and I thought it wasn’t correct:
![before](https://cloud.githubusercontent.com/assets/6409354/24741980/da97cbc2-1ab0-11e7-9b4b-7f331c463da3.PNG)
After, it shows red border at all times:
![after](https://cloud.githubusercontent.com/assets/6409354/24742014/03797f9a-1ab1-11e7-874d-7b5e23cf9d42.PNG)

~Also, I updated my fork to `2.2.10`, and I think I might have messed up something, but although it’s showing 3 commits to the branch, it seems that only one file was changed for `next`—please double check it for me in case I’m missing something.~