### PR TITLE
menu/search: remove border-radius

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -346,6 +346,10 @@
   width: @verticalImageWidth;
 }
 
+.ui.menu > .ui.search > .ui.input > .prompt {
+  border-radius: 0;
+}
+
 /*******************************
           Coupling
 *******************************/


### PR DESCRIPTION
The `border-radius` property in the search input was cutting of parts of
the first letter in the prompt.

The prompt class name seems to be needed from the example in the docs[1]
so resetting the `border-radius` for a search prompt when it's in a menu
component seems like the most straight-forward solution.

[1]: https://semantic-ui.com/collections/menu.html#search

Closes #5281