### PR TITLE
[Popup] Include margin when calculating positions

### DIFF
--- a/src/definitions/modules/popup.js
+++ b/src/definitions/modules/popup.js
@@ -520,21 +520,21 @@ $.fn.popup = function(parameters) {
               // element which is launching popup
               target : {
                 element : $target[0],
-                width   : $target.outerWidth(),
-                height  : $target.outerHeight(),
+                width   : $target.outerWidth(true),
+                height  : $target.outerHeight(true),
                 top     : targetPosition.top,
                 left    : targetPosition.left,
                 margin  : {}
               },
               // popup itself
               popup : {
-                width  : $popup.outerWidth(),
-                height : $popup.outerHeight()
+                width  : $popup.outerWidth(true),
+                height : $popup.outerHeight(true)
               },
               // offset container (or 3d context)
               parent : {
-                width  : $offsetParent.outerWidth(),
-                height : $offsetParent.outerHeight()
+                width  : $offsetParent.outerWidth(true),
+                height : $offsetParent.outerHeight(true)
               },
               // screen boundaries
               screen : {


### PR DESCRIPTION
The popup is incorrectly placed when using these setttings:

* Position is "bottom right"
* The target element has a margin (body in jsfiddle example bellow)

The margin of the parent element is not included when calculating the widhts and heights.

http://jsfiddle.net/8jk6ou0g/1/