### PR TITLE
[Modal] #4196 Disable refreshing for non active/animated modals

### DIFF
--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -290,7 +290,7 @@ $.fn.modal = function(parameters) {
             }
           },
           resize: function() {
-            if( $dimmable.dimmer('is active') ) {
+            if( $dimmable.dimmer('is active') && ( module.is.animating() || module.is.active() ) ) {
               requestAnimationFrame(module.refresh);
             }
           }


### PR DESCRIPTION
This commit solves #4196
When two or more modals coexist on the same page, the refresh method
of each modal is executed, even if one of them is being shown.
By checking if the module is active or being animated, you prevent
conflicts between shown and hidden modals, like the one described in
the issue.