### PR TITLE
[#4470] Dimmer hidden when onHide returns false

### DIFF
--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -452,7 +452,6 @@ $.fn.modal = function(parameters) {
           ;
           if( $visibleModals.length > 0 ) {
             module.debug('Hiding all visible modals');
-            module.hideDimmer();
             $visibleModals
               .modal('hide modal', callback)
             ;


### PR DESCRIPTION
Fix for issue #4470 

When the dimmer gets clicked, the `hideAll` function gets called, which was calling `hideDimmer` regardless of whether or not the modals were actually meant to be hidden. Removed the call to `hideDimmer` since the last visible modal will already call `hideDimmer` if the modal is going to be hidden.