### PR TITLE
[#5236] Improve dropdown clear performance

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -2886,6 +2886,7 @@ $.fn.dropdown = function(parameters) {
           labels: function($labels) {
             $labels = $labels || $module.find(selector.label);
             module.verbose('Removing labels', $labels);
+            var userValues = module.get.userValues();
             $labels
               .each(function(){
                 var
@@ -2894,7 +2895,7 @@ $.fn.dropdown = function(parameters) {
                   stringValue = (value !== undefined)
                     ? String(value)
                     : value,
-                  isUserValue = module.is.userValue(stringValue)
+                  isUserValue = $.inArray(stringValue, userValues) !== -1
                 ;
                 if(settings.onLabelRemove.call($label, value) === false) {
                   module.debug('Label remove callback cancelled removal');
@@ -3136,9 +3137,6 @@ $.fn.dropdown = function(parameters) {
           },
           selection: function() {
             return $module.hasClass(className.selection);
-          },
-          userValue: function(value) {
-            return ($.inArray(value, module.get.userValues()) !== -1);
           },
           upward: function($menu) {
             var $element = $menu || $module;


### PR DESCRIPTION
Fix for issue #5236 

Clearing a multiple selection dropdown involves removing all of the labels. In the `module.remove.labels` function, a list of user values was built up for each label, which involved a lot of retrieval and checks. Removed the `module.is.userValue` function, which wasn't being used anywhere else, and inlined it, retrieving the list of user values only once and making all comparisons against it.