### PR TITLE
Fixed double opacity applied to disabled inputs

### DIFF
--- a/src/definitions/elements/input.less
+++ b/src/definitions/elements/input.less
@@ -82,12 +82,12 @@
 ---------------------*/
 
 .ui.disabled.input,
-.ui.input input[disabled] {
+.ui.input:not(.disabled) input[disabled] {
   opacity: @disabledOpacity;
 }
 
 .ui.disabled.input input,
-.ui.input input[disabled] {
+.ui.input:not(.disabled) input[disabled] {
   pointer-events: none;
 }
 


### PR DESCRIPTION
Fixes #5283 

This PR simply applies the fix suggested by @levithomason
It just checks if the parent of a disabled input has a "disabled"
classname for preventing double opacity being applied. I also added
the same check to the "pointer-events: none", as applying that style
to the parent or the children is enough