### PR TITLE
[Dropdown] fixes not observed changes to select values of select inputs and menus

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -163,6 +163,7 @@ $.fn.dropdown = function(parameters) {
           select: function() {
             if(module.has.input()) {
               selectObserver.observe($input[0], {
+                attributes: true,
                 childList : true,
                 subtree   : true
               });
@@ -171,6 +172,7 @@ $.fn.dropdown = function(parameters) {
           menu: function() {
             if(module.has.menu()) {
               menuObserver.observe($menu[0], {
+                attributes: true,
                 childList : true,
                 subtree   : true
               });


### PR DESCRIPTION
When values of a select input are changed without causing also a label change, the change is not detected and thus the dropdown is out of sync with the underlying DOM.