### PR TITLE
[Dropdown] Multiple Selection Callback Parameters Should Be Consistent

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -2710,7 +2710,7 @@ $.fn.dropdown = function(parameters) {
             else {
               settings.onAdd.call(element, addedValue, addedText, $selectedItem);
             }
-            module.set.value(newValue, addedValue, addedText, $selectedItem);
+            module.set.value(newValue, addedText, $selectedItem);
             module.check.maxSelections();
           }
         },


### PR DESCRIPTION
As illustrated in #2888, the `onChange` callback parameters are inconsistent when adding a new value to a multiple selection, compared to when using single selection, or when removing values from a multiple selection.

The `module.set.value` function only takes 3 arguments, whereas it here was provided with 4. Looking at the `module.remove.value` function, I decided that removing the `addedValue` argument would be most consistent.