### PR TITLE
Fix colors of pointers on inverted colored menu items

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -1425,8 +1425,11 @@ Floated Menu / Item
 
 /* Red */
 .ui.inverted.menu .red.active.item,
-.ui.inverted.red.menu {
-  background-color: @red;
+.ui.inverted.menu .red.active.item:after,
+.ui.inverted.menu .red.active.item:hover:after,
+.ui.inverted.red.menu,
+.ui.inverted.red.menu .active.item:after {
+  background-color: @red !important;
 }
 .ui.inverted.red.menu .item:before {
   background-color: @invertedColoredDividerBackground;
@@ -1437,8 +1440,11 @@ Floated Menu / Item
 
 /* Orange */
 .ui.inverted.menu .orange.active.item,
-.ui.inverted.orange.menu {
-  background-color: @orange;
+.ui.inverted.menu .orange.active.item:after,
+.ui.inverted.menu .orange.active.item:hover:after,
+.ui.inverted.orange.menu,
+.ui.inverted.orange.menu .active.item:after {
+  background-color: @orange !important;
 }
 .ui.inverted.orange.menu .item:before {
   background-color: @invertedColoredDividerBackground;
@@ -1449,8 +1455,11 @@ Floated Menu / Item
 
 /* Yellow */
 .ui.inverted.menu .yellow.active.item,
-.ui.inverted.yellow.menu {
-  background-color: @yellow;
+.ui.inverted.menu .yellow.active.item:after,
+.ui.inverted.menu .yellow.active.item:hover:after,
+.ui.inverted.yellow.menu,
+.ui.inverted.yellow.menu .active.item:after {
+  background-color: @yellow !important;
 }
 .ui.inverted.yellow.menu .item:before {
   background-color: @invertedColoredDividerBackground;
@@ -1461,8 +1470,11 @@ Floated Menu / Item
 
 /* Olive */
 .ui.inverted.menu .olive.active.item,
-.ui.inverted.olive.menu {
-  background-color: @olive;
+.ui.inverted.menu .olive.active.item:after,
+.ui.inverted.menu .olive.active.item:hover:after,
+.ui.inverted.olive.menu,
+.ui.inverted.olive.menu .active.item:after {
+  background-color: @olive !important;
 }
 .ui.inverted.olive.menu .item:before {
   background-color: @invertedColoredDividerBackground;
@@ -1473,8 +1485,11 @@ Floated Menu / Item
 
 /* Green */
 .ui.inverted.menu .green.active.item,
-.ui.inverted.green.menu {
-  background-color: @green;
+.ui.inverted.menu .green.active.item:after,
+.ui.inverted.menu .green.active.item:hover:after,
+.ui.inverted.green.menu,
+.ui.inverted.green.menu .active.item:after {
+  background-color: @green !important;
 }
 .ui.inverted.green.menu .item:before {
   background-color: @invertedColoredDividerBackground;
@@ -1485,8 +1500,11 @@ Floated Menu / Item
 
 /* Teal */
 .ui.inverted.menu .teal.active.item,
-.ui.inverted.teal.menu {
-  background-color: @teal;
+.ui.inverted.menu .teal.active.item:after,
+.ui.inverted.menu .teal.active.item:hover:after,
+.ui.inverted.teal.menu,
+.ui.inverted.teal.menu .active.item:after {
+  background-color: @teal !importantl;
 }
 .ui.inverted.teal.menu .item:before {
   background-color: @invertedColoredDividerBackground;
@@ -1497,8 +1515,11 @@ Floated Menu / Item
 
 /* Blue */
 .ui.inverted.menu .blue.active.item,
-.ui.inverted.blue.menu {
-  background-color: @blue;
+.ui.inverted.menu .blue.active.item:after,
+.ui.inverted.menu .blue.active.item:hover:after,
+.ui.inverted.blue.menu,
+.ui.inverted.blue.menu .active.item:after {
+  background-color: @blue !important;
 }
 .ui.inverted.blue.menu .item:before {
   background-color: @invertedColoredDividerBackground;
@@ -1509,8 +1530,11 @@ Floated Menu / Item
 
 /* Violet */
 .ui.inverted.menu .violet.active.item,
-.ui.inverted.violet.menu {
-  background-color: @violet;
+.ui.inverted.menu .violet.active.item:after,
+.ui.inverted.menu .violet.active.item:hover:after,
+.ui.inverted.violet.menu,
+.ui.inverted.violet.menu .active.item:after {
+  background-color: @violet !important;
 }
 .ui.inverted.violet.menu .item:before {
   background-color: @invertedColoredDividerBackground;
@@ -1521,8 +1545,11 @@ Floated Menu / Item
 
 /* Purple */
 .ui.inverted.menu .purple.active.item,
-.ui.inverted.purple.menu {
-  background-color: @purple;
+.ui.inverted.menu .purple.active.item:after,
+.ui.inverted.menu .purple.active.item:hover:after,
+.ui.inverted.purple.menu,
+.ui.inverted.purple.menu .active.item:after {
+  background-color: @purple !important;
 }
 .ui.inverted.purple.menu .item:before {
   background-color: @invertedColoredDividerBackground;
@@ -1533,8 +1560,11 @@ Floated Menu / Item
 
 /* Pink */
 .ui.inverted.menu .pink.active.item,
-.ui.inverted.pink.menu {
-  background-color: @pink;
+.ui.inverted.menu .pink.active.item:after,
+.ui.inverted.menu .pink.active.item:hover:after,
+.ui.inverted.pink.menu,
+.ui.inverted.pink.menu .active.item:after {
+  background-color: @pink !important;
 }
 .ui.inverted.pink.menu .item:before {
   background-color: @invertedColoredDividerBackground;
@@ -1545,8 +1575,11 @@ Floated Menu / Item
 
 /* Brown */
 .ui.inverted.menu .brown.active.item,
-.ui.inverted.brown.menu {
-  background-color: @brown;
+.ui.inverted.menu .brown.active.item:after,
+.ui.inverted.menu .brown.active.item:hover:after,
+.ui.inverted.brown.menu,
+.ui.inverted.brown.menu .active.item:after {
+  background-color: @brown !important;
 }
 .ui.inverted.brown.menu .item:before {
   background-color: @invertedColoredDividerBackground;
@@ -1557,8 +1590,11 @@ Floated Menu / Item
 
 /* Grey */
 .ui.inverted.menu .grey.active.item,
-.ui.inverted.grey.menu {
-  background-color: @grey;
+.ui.inverted.menu .grey.active.item:after,
+.ui.inverted.menu .grey.active.item:hover:after,
+.ui.inverted.grey.menu,
+.ui.inverted.grey.menu .active.item:after {
+  background-color: @grey !important;
 }
 .ui.inverted.grey.menu .item:before {
   background-color: @invertedColoredDividerBackground;


### PR DESCRIPTION
Added three more selectors to each color:

```
.ui.inverted.color.menu .active.item:after            //for colored menus
.ui.inverted.menu .color.active.item:after            //for colored menu items (individual)
.ui.inverted.menu .color.active.item:hover:after  //for colored menu items (individual) - hover
```

Also needed to add !important to each to override the standard inverted color.

This is my first PR. And my first time using LESS (although I didn't really do anything LESSy). Comments and alternate suggestions welcome!

Ref: #2355