### PR TITLE
[Segment] Add .floated to Segments group

### DIFF
--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -629,11 +629,13 @@
 --------------------*/
 
 .ui.floated.segment,
-.ui[class*="left floated"].segment {
+.ui[class*="left floated"].segment,
+.ui[class*="left floated"].segments {
   float: left;
   margin-right: @floatedDistance;
 }
-.ui[class*="right floated"].segment {
+.ui[class*="right floated"].segment,
+.ui[class*="right floated"].segments {
   float: right;
   margin-left: @floatedDistance;
 }


### PR DESCRIPTION
A single `.segment` element can have `.left/right.floated` class to make it float. A `.segments` group of segments isn't affected by these classes. Since they are just a group of segments one could expect this behaviour.

This PR adds `.ui[class*="left floated"].segments` and `.ui[class*="right floated"].segments` classes to the segment definition.