### PR TITLE
[Segment] Add text alignment to segments group

### DIFF
--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -614,13 +614,16 @@
        Aligned
 --------------------*/
 
-.ui[class*="left aligned"].segment {
+.ui[class*="left aligned"].segment,
+.ui[class*="left aligned"].segments {
   text-align: left;
 }
-.ui[class*="right aligned"].segment {
+.ui[class*="right aligned"].segment,
+.ui[class*="right aligned"].segments {
   text-align: right;
 }
-.ui[class*="center aligned"].segment {
+.ui[class*="center aligned"].segment,
+.ui[class*="center aligned"].segments {
   text-align: center;
 }
 


### PR DESCRIPTION
A single `.segment` element can have classes to define their text-alignment. A `.segments` group of segments isn't affected by these classes. Since they are just a group of segments one could expect this behaviour.

This PR adds the classes

```
.ui[class*="left aligned"].segments
.ui[class*="right aligned"].segments
.ui[class*="center aligned"].segments
```

in order to set a text-alignment for the whole segments group which will be inherited by the `.segment` children.