### PR TITLE
[Build Tools] Fixes #5418 Express installation custom folder

### DIFF
--- a/tasks/config/user.js
+++ b/tasks/config/user.js
@@ -7,7 +7,6 @@ var
   extend          = require('extend'),
   fs              = require('fs'),
   path            = require('path'),
-  requireDotFile  = require('require-dot-file'),
 
   // semantic.json defaults
   defaults        = require('./defaults'),
@@ -28,7 +27,7 @@ var
 
 try {
   // looks for config file across all parent directories
-  userConfig = requireDotFile('semantic.json');
+  userConfig = require('../../../semantic.json');
 }
 catch(error) {
   if(error.code === 'MODULE_NOT_FOUND') {


### PR DESCRIPTION
I've gone through [require-dot-file](https://github.com/jlukic/require-dot-file/blob/master/index.js) module and it doesn't exactly do the job that is required for installation. The `require-dot-file` module recursively goes higher up from the `node_modules` directory. If you `console.log` the currentPath and nexDirectory, you clearly see :

```js
currentPath: ../package.json
nextDirectory: /home/skd/webserver/myproject/src/web
currentPath: /home/skd/webserver/myproject/src/web/package.json
nextDirectory: /home/skd/webserver/myproject/src
currentPath: /home/skd/webserver/myproject/src/package.json
nextDirectory: /home/skd/webserver/myproject
currentPath: /home/skd/webserver/myproject/package.json
nextDirectory: /home/skd/webserver
currentPath: /home/skd/webserver/package.json
nextDirectory: /home/skd
currentPath: /home/skd/package.json
nextDirectory: /home
currentPath: /home/package.json
nextDirectory: /
currentPath: /package.json
nextDirectory: /
```

But in the expression installation, if I wish to install to a sub sub folder at `/home/skd/webserver/myproject/src/web/foo/bar`, then it will search for a `semantic.json` from `/home/skd/webserver/myproject/src/web` and higher directories and hence the config is not accesible and hence `gulpConfig` reverts to default configuration.

One possible fix is to use, the walk directory parameter of `require-dot-file` `requireDotFile('semantic.json','/home/skd/webserver/myproject/src/web')`  to specify which folder to start the walk from. But this is kinda redundant because we have mention the project location in `semantic.json`. Therefore, the best way is to get rid of `require-dot-file` and use the one invariant for this case. Which is, `semantic.json` is always 3 levels higher than `user.js`

Fixes: #5418 