### PR TITLE
[Icon] #5468 Add an alias to 500px’s class name

### DIFF
--- a/src/themes/default/elements/icon.overrides
+++ b/src/themes/default/elements/icon.overrides
@@ -712,7 +712,7 @@ i.icon.firefox:before { content: "\f269"; }
 i.icon.opera:before { content: "\f26a"; }
 i.icon.internet.explorer:before { content: "\f26b"; }
 i.icon.contao:before { content: "\f26d"; }
-i.icon.five.hundred.px:before { content: "\f26e"; }
+i.icon.\35 00px:before { content: "\f26e"; }
 i.icon.amazon:before { content: "\f270"; }
 i.icon.houzz:before { content: "\f27c"; }
 i.icon.vimeo:before { content: "\f27d"; }
@@ -989,3 +989,4 @@ i.icon.s15:before { content: "\f2cd"; }
 i.icon.bath:before { content: "\f2cd"; }
 i.icon.times.rectangle:before { content: "\f2d3"; }
 i.icon.times.rectangle.outline:before { content: "\f2d4"; }
+i.icon.five.hundred.px:before { content: "\f26e"; }

--- a/src/themes/default/elements/icon.overrides
+++ b/src/themes/default/elements/icon.overrides
@@ -712,7 +712,7 @@ i.icon.firefox:before { content: "\f269"; }
 i.icon.opera:before { content: "\f26a"; }
 i.icon.internet.explorer:before { content: "\f26b"; }
 i.icon.contao:before { content: "\f26d"; }
-i.icon.\35 00px:before { content: "\f26e"; }
+i.icon.five.hundred.px:before { content: "\f26e"; }
 i.icon.amazon:before { content: "\f270"; }
 i.icon.houzz:before { content: "\f27c"; }
 i.icon.vimeo:before { content: "\f27d"; }


### PR DESCRIPTION
Resolves #5468. The commentary below is outdated, and the new class name was added as an alias instead.

Apparently, classes starting with a digit can’t be used in `Pug.js`, so I’d like to suggest changing it from escaped `\35 00px` to `.five.hundred.px` (as [Wikipedia says the brand is pronounced](https://www.wikiwand.com/en/500px)). I understand that it’s a breaking change, but it’s also possible that there’re other libraries that might have an issue with such class names, and maybe it’s better to support these use cases out of the box.