### PR TITLE
[Build Tools] Default theme folder can be configured

### DIFF
--- a/src/theme.config.example
+++ b/src/theme.config.example
@@ -76,6 +76,9 @@
             Folders
 *******************************/
 
+/* Path to default theme folder */
+@defaultThemeFolder : 'default';
+
 /* Path to theme packages */
 @themesFolder : 'themes';
 

--- a/src/theme.less
+++ b/src/theme.less
@@ -13,7 +13,7 @@
 ---------------------*/
 
 /* Default site.variables */
-@import "@{themesFolder}/default/globals/site.variables";
+@import "@{themesFolder}/@{defaultThemeFolder}/globals/site.variables";
 
 /* Packaged site.variables */
 @import "@{themesFolder}/@{site}/globals/site.variables";
@@ -30,7 +30,7 @@
 ---------------------*/
 
 /* Default */
-@import "@{themesFolder}/default/@{type}s/@{element}.variables";
+@import "@{themesFolder}/@{defaultThemeFolder}/@{type}s/@{element}.variables";
 
 /* Packaged Theme */
 @import (optional) "@{themesFolder}/@{theme}/@{type}s/@{element}.variables";
@@ -56,6 +56,7 @@
 -------------------*/
 
 .loadUIOverrides() {
+  @import (optional) "@{themesFolder}/@{defaultThemeFolder}/@{type}s/@{element}.overrides";
   @import (optional) "@{themesFolder}/@{theme}/@{type}s/@{element}.overrides";
   @import (optional) "@{siteFolder}/@{type}s/@{element}.overrides";
 }


### PR DESCRIPTION
This an enhancement for making the default theme folder configurable. In the following, I describe a use case which motivates this pull request.

We use Semantic-UI at VANTAiO for styling our portal solutions. We provide a common Semantic theme which can be adjusted for each customer.

We implemented this by creating a copy of the default Semantic theme and naming it "common". We adjusted variables in the .variables files and extended the css in the .overrides files. When we need to customize a theme for a customer, we copy this common theme. All adjustments are performed in this theme.

This appproach leads to problems. When we want to perform changes in the common theme, we have to manually adjust the customized theme files. Furthermore, there is lots of redundant code. Differences between the common and the customized themes cannot be seen directly.

A solution can be performed as followed with the current inheritance architecture of Semantic:
- Put individual variable adjustments and css extensions in the custom theme
- Put the common variable definitions and css extensions in the site folder

It has a major disadvantage:
You cannot use the same variable or css statement in the custom and common theme. The common theme in the sites folder overrides the variable or css statement from the custom folder.

A better approach is presented in this pull request. You can configure the default theme folder in theme.config and put all your common theme code there. For that you copy the default folder and name it e.g. "common". Then you can adjust variables in the .variables files and add css statements in the .overrides files. Consequently, all other themes inherit the variables and new css rules. So they can override them. Changes only have to be made in the common theme.

This change does not break anything because the "default" folder is configured as the defaultThemeFolder variable. I guess this pull request is interesting for all Semantic UI users who build multi-theme solutions.

Another advantage of this pull request is that changes of a new semantic version do not break the current styling because everything is fixed in the common theme folder. But one has to manually merge the default theme with the common theme. Since this feature is opt-in, there is no problem with it.