### PR TITLE
[Dropdown] #5535 Add the ability to specify an event that the dropdown component will use to show sub-menus

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1219,8 +1219,8 @@ $.fn.dropdown = function(parameters) {
                   });
                   module.animate.show(false, $subMenu);
                 }
+                event.preventDefault();
               }
-              event.preventDefault();
             }
           },
 
@@ -1609,6 +1609,7 @@ $.fn.dropdown = function(parameters) {
             if( module.can.activate( $(element) ) ) {
               module.set.selected(value, $(element));
               if(module.is.multiple() && !module.is.allFiltered()) {
+                event.preventDefault();
                 return;
               }
               else {
@@ -1625,6 +1626,7 @@ $.fn.dropdown = function(parameters) {
             if( module.can.activate( $(element) ) ) {
               module.set.value(value, $(element));
               if(module.is.multiple() && !module.is.allFiltered()) {
+                event.preventDefault();
                 return;
               }
               else {
@@ -1640,11 +1642,13 @@ $.fn.dropdown = function(parameters) {
             ;
             module.set.selected(value, $(element));
             module.hideAndClear();
+            event.preventDefault();
           },
 
           hide: function(text, value, element) {
             module.set.value(value, text);
             module.hideAndClear();
+            event.preventDefault();
           }
 
         },

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -27,6 +27,7 @@ $.fn.dropdown = function(parameters) {
     moduleSelector = $allModules.selector || '',
 
     hasTouch       = ('ontouchstart' in document.documentElement),
+    onTouchMove    = false,
     time           = new Date().getTime(),
     performance    = [],
 
@@ -548,7 +549,9 @@ $.fn.dropdown = function(parameters) {
               ;
             }
             $menu
-              .on('touchstart' + eventNamespace, selector.item, module.event.item.click)
+              .on('touchstart' + eventNamespace, selector.item, module.event.touch.start)
+              .on('touchmove' + eventNamespace, selector.item, module.event.touch.move)
+              .on('touchend' + eventNamespace, selector.item, module.event.item.click)
             ;
           },
           keyboardEvents: function() {
@@ -965,6 +968,14 @@ $.fn.dropdown = function(parameters) {
               }
             }
           },
+          touch: {
+            start: function () {
+              onTouchMove = false;
+            },
+            move: function () {
+              onTouchMove = true;
+            },
+          },
           search: {
             focus: function() {
               activated = true;
@@ -1161,6 +1172,9 @@ $.fn.dropdown = function(parameters) {
                 hasSubMenu     = ($subMenu.length > 0),
                 isBubbledEvent = ($subMenu.find($target).length > 0)
               ;
+              if (onTouchMove) {
+                return;
+              }
               // prevents IE11 bug where menu receives focus even though `tabindex=-1`
               if(module.has.menuSearch()) {
                 $(document.activeElement).blur();

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1219,8 +1219,8 @@ $.fn.dropdown = function(parameters) {
                   });
                   module.animate.show(false, $subMenu);
                 }
-                event.preventDefault();
               }
+              event.preventDefault();
             }
           },
 


### PR DESCRIPTION
Resolves #5535.

Defaults to `hover`, which is how it is now. [Here’s a JSFiddle](https://jsfiddle.net/jmh27f53/) ([embedded link for mobile devices](https://jsfiddle.net/jmh27f53/embedded/result)) to see it in action with the latest changes from `master` and these settings:
```JS
$('.ui.dropdown')
  .dropdown({
    toggleSubMenusOn: 'click',
    allowCategorySelection: true
  })
```
Something to note:
- `allowCategorySelection: true` is ignored when `toggleSubMenusOn` is set to `'click'`.
- `touchstart` now uses `module.event.item.click` instead of `mouseenter`. This allows for better control over sub-menus on devices that use the event—you couldn’t close menus by tapping on their parent `.item`s before. Because of that,  `allowCategorySelection: true` is ignored when `toggleSubMenusOn` is set to `'hover'` on touch devices to allow the interaction with submenus (same as now).
- I’m not sure what to think about the extensive use of touch detection, because I’ve heard that `('ontouchstart' in document.documentElement)` can be unreliable, but I didn’t find any proof of that, and it’s already being used by the component, so I’m guessing it’s okay.

I tested it extensively on various devices—please let me know if I broke something, and I’ll push another commit to fix it.