### PR TITLE
Fix modal scrolling for overflow

### DIFF
--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -533,7 +533,7 @@ $.fn.modal = function(parameters) {
 
         cacheSizes: function() {
           var
-            modalHeight = $module.outerHeight()
+            modalHeight = $module[0].scrollHeight;
           ;
           if(module.cache === undefined || modalHeight !== 0) {
             module.cache = {


### PR DESCRIPTION
When modal contains absolute positioned element which is taller than available screen, the modal scrolling is not triggered. By using `scrollHeight` the extended height is taken into account.

`scrollHeight` is how Bootstrap modal determines whether to trigger scrolling.

The bug demo:
https://jsfiddle.net/lulalala/ngjvzwkc/1/