### PR TITLE
Fixed Gulp Build Comments Error

### DIFF
--- a/tasks/config/tasks.js
+++ b/tasks/config/tasks.js
@@ -145,7 +145,9 @@ module.exports = {
     /* Minified JS Settings */
     uglify: {
       mangle   : true,
-      comments : 'some'
+	  output: {
+        comments: 'some'
+	  }
     },
 
     /* Minified Concat CSS Settings */
@@ -159,7 +161,9 @@ module.exports = {
     /* Minified Concat JS */
     concatUglify: {
       mangle   : true,
-      comments : false
+      output   : {
+	    comments: false
+      }
     }
 
   }

--- a/tasks/config/tasks.js
+++ b/tasks/config/tasks.js
@@ -145,9 +145,9 @@ module.exports = {
     /* Minified JS Settings */
     uglify: {
       mangle   : true,
-	  output: {
+      output: {
         comments: 'some'
-	  }
+      }
     },
 
     /* Minified Concat CSS Settings */
@@ -162,7 +162,7 @@ module.exports = {
     concatUglify: {
       mangle   : true,
       output   : {
-	    comments: false
+        comments: false
       }
     }
 


### PR DESCRIPTION
Fix #5391 Gulp Build `preserveComments` is not a supported option or `comments` is not a supported option