### PR TITLE
[Button] Fix the button’s inheritance issue on hover

### DIFF
--- a/src/definitions/elements/button.less
+++ b/src/definitions/elements/button.less
@@ -72,7 +72,8 @@
   color: @hoverColor;
 }
 
-.ui.button:hover .icon {
+.ui.button:hover > .icon,
+.ui.button:hover > .content > .icon {
   opacity: @iconHoverOpacity;
 }
 
@@ -87,7 +88,8 @@
   box-shadow: @focusBoxShadow !important;
 }
 
-.ui.button:focus .icon {
+.ui.button:focus > .icon,
+.ui.button:focus > .content > .icon {
   opacity: @iconFocusOpacity;
 }
 


### PR DESCRIPTION
Child elements of `.ui.button` that have an `.icon` class incorrectly inherit one of its rules. Can be reproduced using the `search in-menu` pattern; click on a button to show the menu, then hover in and out a button to see the barely noticeable opacity change: https://jsfiddle.net/upvbgwxa/