### PR TITLE
fix csp transition, replace attr() by css()

### DIFF
--- a/src/definitions/modules/transition.js
+++ b/src/definitions/modules/transition.js
@@ -247,14 +247,25 @@ $.fn.transition = function() {
               style          = $module.attr('style'),
               userStyle      = module.get.userStyle(),
               displayType    = module.get.displayType(),
-              overrideStyle  = userStyle + 'display: ' + displayType + ' !important;',
+              overrideStyle  = userStyle + 'display: ' + displayType,
               currentDisplay = $module.css('display'),
               emptyStyle     = (style === undefined || style === '')
             ;
             if(currentDisplay !== displayType) {
               module.verbose('Overriding default display to show element', displayType);
+              var
+                styleLines = overrideStyle.split(';'),
+                styles = {},
+                line
+              ;
+              styleLines.forEach(function(style){
+                line = style.split(':');
+                if(line.length === 2) {
+                  styles[line[0].trim()] = line[1].trim();
+                }
+              });
               $module
-                .attr('style', overrideStyle)
+                .css(styles)
               ;
             }
             else if(emptyStyle) {


### PR DESCRIPTION
The components that use `transicion.js` have problems with `csp`, this allows to avoid that problem, i replaced attr() by css().
Fix: #5630.
![transition](https://user-images.githubusercontent.com/11939055/29369370-0b2d7b1e-8268-11e7-856c-56643f18d42a.gif)