### PR TITLE
[Dropdown] Fix inheritance issues with the `.floating` variation

### DIFF
--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -1200,7 +1200,7 @@ select.ui.dropdown {
     Floating
 ---------------*/
 
-.ui.floating.dropdown .menu {
+.ui.floating.dropdown > .menu {
   left: 0;
   right: auto;
   box-shadow: @floatingMenuBoxShadow !important;


### PR DESCRIPTION
Fixes incorrect sub-menu position in dropdowns that use the `.floating` variation; [test case](https://jsfiddle.net/9bc92f95/).