### PR TITLE
[Dropdown] Fix dropdown’s inheritance issues for button groups

### DIFF
--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -316,7 +316,7 @@
 /* Automatically float dropdown menu right on last menu item */
 .ui.menu .right.menu .dropdown:last-child .menu,
 .ui.menu .right.dropdown.item .menu,
-.ui.buttons > .ui.dropdown:last-child .menu {
+.ui.buttons > .ui.dropdown:last-child > .menu {
   left: auto;
   right: 0em;
 }


### PR DESCRIPTION
Fixes incorrect sub-menu position in dropdowns that use button groups; [test case](https://jsfiddle.net/bw1ka4ze/).