### PR TITLE
[Menu][Dropdown] #5657 Fix incorrect width of sub menus in vertical menus

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -284,7 +284,7 @@
 }
 .ui.vertical.menu .dropdown.item .menu {
   left: 100%;
-  min-width: 0;
+  min-width: max-content;
   margin: 0em 0em 0em @dropdownMenuDistance;
   box-shadow: @dropdownVerticalMenuBoxShadow;
   border-radius: 0em @dropdownMenuBorderRadius @dropdownMenuBorderRadius @dropdownMenuBorderRadius;


### PR DESCRIPTION
Resolves #5657. The dropdown component uses `min-width: max-content` ([source](https://github.com/Semantic-Org/Semantic-UI/blob/master/src/definitions/modules/dropdown.less#L50)), I don’t think there’s a reason to do it differently in vertical menus.