### PR TITLE
[Dropdown] Add hook beforeLabelCreate()

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -2538,6 +2538,7 @@ $.fn.dropdown = function(parameters) {
                       module.save.remoteData(selectedText, selectedValue);
                     }
                     if(settings.useLabels) {
+                      [selectedValue,selectedText] = settings.beforeLabelCreate.call($selected,selectedValue,selectedText);
                       module.add.value(selectedValue, selectedText, $selected);
                       module.add.label(selectedValue, selectedText, shouldAnimate);
                       module.set.activeItem($selected);
@@ -3691,16 +3692,17 @@ $.fn.dropdown.settings = {
   },
 
   /* Callbacks */
-  onChange      : function(value, text, $selected){},
-  onAdd         : function(value, text, $selected){},
-  onRemove      : function(value, text, $selected){},
-
-  onLabelSelect : function($selectedLabels){},
-  onLabelCreate : function(value, text) { return $(this); },
-  onLabelRemove : function(value) { return true; },
-  onNoResults   : function(searchTerm) { return true; },
-  onShow        : function(){},
-  onHide        : function(){},
+  onChange         : function(value, text, $selected){},
+  onAdd            : function(value, text, $selected){},
+  onRemove         : function(value, text, $selected){},
+  
+  onLabelSelect    : function($selectedLabels){},
+  beforeLabelCreate: function(value,text){ return [value,text]; },
+  onLabelCreate    : function(value, text) { return $(this); },
+  onLabelRemove    : function(value) { return true; },
+  onNoResults      : function(searchTerm) { return true; },
+  onShow           : function(){},
+  onHide           : function(){},
 
   /* Component */
   name           : 'Dropdown',

--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -2523,14 +2523,15 @@ $.fn.dropdown = function(parameters) {
             $selectedItem
               .each(function() {
                 var
-                  $selected      = $(this),
-                  selectedText   = module.get.choiceText($selected),
-                  selectedValue  = module.get.choiceValue($selected, selectedText),
-
-                  isFiltered     = $selected.hasClass(className.filtered),
-                  isActive       = $selected.hasClass(className.active),
-                  isUserValue    = $selected.hasClass(className.addition),
-                  shouldAnimate  = (isMultiple && $selectedItem.length == 1)
+                  $selected          = $(this),
+                  selectedText       = module.get.choiceText($selected),
+                  selectedValue      = module.get.choiceValue($selected, selectedText),
+                  
+                  isFiltered         = $selected.hasClass(className.filtered),
+                  isActive           = $selected.hasClass(className.active),
+                  isUserValue        = $selected.hasClass(className.addition),
+                  shouldAnimate      = (isMultiple && $selectedItem.length == 1),
+                  updatedLabelValues = [];
                 ;
                 if(isMultiple) {
                   if(!isActive || isUserValue) {
@@ -2538,7 +2539,9 @@ $.fn.dropdown = function(parameters) {
                       module.save.remoteData(selectedText, selectedValue);
                     }
                     if(settings.useLabels) {
-                      [selectedValue,selectedText] = settings.beforeLabelCreate.call($selected,selectedValue,selectedText);
+                      updatedLabelValues = settings.beforeLabelCreate.call($selected,selectedValue,selectedText);
+                      selectedValue = updatedLabelValues[0];
+                      selectedText = updatedLabelValues[1];
                       module.add.value(selectedValue, selectedText, $selected);
                       module.add.label(selectedValue, selectedText, shouldAnimate);
                       module.set.activeItem($selected);


### PR DESCRIPTION
I have a need to be able to access the actual element that is clicked in a multiselect dropdown.  I have data stored in `data-*` attributes that I can't access in `onCreateLabel()`.  This hook is called before `onCreateLabel()`, and is called in the context of the element clicked.