### PR TITLE
[Menu] #5741 Fix the menu’s rules that were incorrectly applied to the dropdown in certain circumstances due to inheritance

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -458,21 +458,21 @@ Floated Menu / Item
 -------------------*/
 
 /* Left Floated */
-.ui.menu:not(.vertical) .left.item,
-.ui.menu:not(.vertical) .left.menu {
+.ui.menu:not(.vertical) > .left.item,
+.ui.menu:not(.vertical) > .left.menu {
   display: flex;
   margin-right: auto !important;
 }
 /* Right Floated */
-.ui.menu:not(.vertical) .right.item,
-.ui.menu:not(.vertical) .right.menu {
+.ui.menu:not(.vertical) > .right.item,
+.ui.menu:not(.vertical) > .right.menu {
   display: flex;
   margin-left: auto !important;
 }
 
 /* Swapped Borders */
-.ui.menu .right.item::before,
-.ui.menu .right.menu > .item::before {
+.ui.menu > .right.item::before,
+.ui.menu > .right.menu > .item::before {
   right: auto;
   left: 0;
 }


### PR DESCRIPTION
Resolves #5741. `.left.item`/`.right.item` rules don’t affect the dropdown component, but I think that it’d be better to limit them as well.