### PR TITLE
[Input][Button] #5760 Fix .ui.button not inheriting .ui.action.input’s size

### DIFF
--- a/src/definitions/elements/input.less
+++ b/src/definitions/elements/input.less
@@ -408,6 +408,7 @@
   display: flex;
   align-items: center;
   flex: 0 0 auto;
+  font-size: inherit;
 }
 .ui.action.input > .button,
 .ui.action.input > .buttons > .button {


### PR DESCRIPTION
Resolves #5760.