### PR TITLE
[Dropdown] Fix #5231 Clicking on the dropdown icon will generate multiple hits to the server (when no results are returned)

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -758,6 +758,9 @@ $.fn.dropdown = function(parameters) {
                 module.setup.menu({
                   values: response[fields.remoteValues]
                 });
+                if(0 == response[fields.remoteValues].length) {
+                  module.add.message(message.noResults);
+                }
                 callback();
               }
             }


### PR DESCRIPTION
I resolved the loop by adding the noResults message in queryRemote (which is specific to this scenario, so it seemed appropriate) if the length of results is zero