### PR TITLE
[Button] Explicitly set vertically attached singular button widths to 100%

### DIFF
--- a/src/definitions/elements/button.less
+++ b/src/definitions/elements/button.less
@@ -1006,9 +1006,11 @@
 /* Top / Bottom */
 .ui.attached.top.button {
   border-radius: @borderRadius @borderRadius 0em 0em;
+  width: 100%;
 }
 .ui.attached.bottom.button {
   border-radius: 0em 0em @borderRadius @borderRadius;
+  width: 100%;
 }
 
 /* Left / Right */
@@ -3423,4 +3425,3 @@
 }
 
 .loadUIOverrides();
-


### PR DESCRIPTION
Fixes a bug which caused vertically attached singular `<button>` elements to not take the width of their containers, despite being a block-level element.

fixes #5851