### PR TITLE
Category search for a local source

### DIFF
--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -578,7 +578,7 @@ $.fn.search = function(parameters) {
               searchExp    = searchTerm.toString().replace(regExp.escape, '\\$&'),
               matchRegExp  = new RegExp(regExp.beginsWith + searchExp, 'i'),
               // stop category recurrsion
-              recur        = recur || true
+              recur        = recur || true,
 
               // avoid duplicates when pushing results
               addResult = function(array, result) {
@@ -628,7 +628,7 @@ $.fn.search = function(parameters) {
             });
             
             if (recur && settings.type === 'category') {
-              $.each(source, (label, content) => {
+              $.each(source, function(label, content) {
                 if (content.results) {
                   var matchingChildren = module.search.object(searchTerm, content.results, searchFields, false)
 

--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -571,12 +571,14 @@ $.fn.search = function(parameters) {
               .api('query')
             ;
           },
-          object: function(searchTerm, source, searchFields) {
+          object: function(searchTerm, source, searchFields, recur) {
             var
               results      = [],
               fuzzyResults = [],
               searchExp    = searchTerm.toString().replace(regExp.escape, '\\$&'),
               matchRegExp  = new RegExp(regExp.beginsWith + searchExp, 'i'),
+              // stop category recurrsion
+              recur        = recur || true
 
               // avoid duplicates when pushing results
               addResult = function(array, result) {
@@ -624,6 +626,20 @@ $.fn.search = function(parameters) {
                 }
               });
             });
+            
+            if (recur && settings.type === 'category') {
+              $.each(source, (label, content) => {
+                if (content.results) {
+                  var matchingChildren = module.search.object(searchTerm, content.results, searchFields, false)
+
+                  if (matchingChildren.length) {
+                    content.results = matchingChildren
+                    addResult(results, content);
+                  }
+                }
+              })
+            }
+            
             return $.merge(results, fuzzyResults);
           }
         },


### PR DESCRIPTION
This will add the ability to use a category search with a local source object

This will find 'bar' from the following structure
And 'foo' if 'name' is passed in with the searchFields array
```js
source: [
  {
    name: 'Foo',
    results: [
      { title: 'bar' },
    ],
  },
],
```