### PR TITLE
Added onChanging callback to accordion

### DIFF
--- a/dist/semantic.js
+++ b/dist/semantic.js
@@ -2374,6 +2374,7 @@ $.fn.accordion = function(parameters) {
           }
           module.debug('Opening accordion content', $activeTitle);
           settings.onOpening.call($activeContent);
+          settings.onChanging.call($activeContent);
           if(settings.exclusive) {
             module.closeOthers.call($activeTitle);
           }
@@ -2437,6 +2438,7 @@ $.fn.accordion = function(parameters) {
           if((isActive || isOpening) && !isClosing) {
             module.debug('Closing accordion content', $activeContent);
             settings.onClosing.call($activeContent);
+            settings.onChanging.call($activeContent);
             $activeTitle
               .removeClass(className.active)
             ;
@@ -2784,6 +2786,7 @@ $.fn.accordion.settings = {
   onOpen          : function(){}, // callback after open animation
   onClosing       : function(){}, // callback before closing animation
   onClose         : function(){}, // callback after closing animation
+  onChanging      : function(){}, // callback before closing or opening animation
   onChange        : function(){}, // callback after closing or opening animation
 
   error: {


### PR DESCRIPTION
There are callbacks that happen before open and close, so why not change as well?
Well this fixes that!

I added it so that I have a folder icon on the accordion, so I could just add
`onChanging: function() { $('#file_icon').toggleClass("open"); }`
to initialization to make it change the icon to be open or closed before the animation happened, as opposed to after the animation
![accordion](https://user-images.githubusercontent.com/7832163/32014049-386ae64a-b97a-11e7-9f5a-456de25cd6a6.gif)
