### PR TITLE
Swap huge and big in menu.variables #5899

### DIFF
--- a/src/themes/default/collections/menu.variables
+++ b/src/themes/default/collections/menu.variables
@@ -453,6 +453,6 @@
 @smallWidth: 13rem;
 @mediumWidth: 15rem;
 @largeWidth: 18rem;
-@hugeWidth: 20rem;
-@bigWidth: 22rem;
+@bigWidth: 20rem;
+@hugeWidth: 22rem;
 @massiveWidth: 25rem;

--- a/src/themes/default/collections/menu.variables
+++ b/src/themes/default/collections/menu.variables
@@ -443,8 +443,8 @@
 @tiny: @12px;
 @small: @13px;
 @large: @15px;
-@huge: @16px;
-@big: @17px;
+@big: @16px;
+@huge: @17px;
 @massive: @18px;
 
 /* Sizes */


### PR DESCRIPTION
Issue #5899 
Closes #5899

Changed menu variables to be _big -> huge -> massive_ to be consistent with global variables.