### PR TITLE
[Dropdown] Fix IE11 dropdown re-focus issue

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -1196,9 +1196,7 @@ $.fn.dropdown = function(parameters) {
                 isBubbledEvent = ($subMenu.find($target).length > 0)
               ;
               // prevents IE11 bug where menu receives focus even though `tabindex=-1`
-              if(module.has.menuSearch()) {
-                $(document.activeElement).blur();
-              }
+              $(document.activeElement).blur();
               if(!isBubbledEvent && (!hasSubMenu || settings.allowCategorySelection)) {
                 if(module.is.searchSelection()) {
                   if(settings.allowAdditions) {


### PR DESCRIPTION
@jokeronaldo Here is [JSFiddle](https://jsfiddle.net/ca0rovs3/116/). 

1. Please, use IE11 to reproduce the bug. 
2. Click on user icon and choose `Settings` for example. 

Actual result: dropdown will be closed and immediately opened.
Expected result: dropdown is closing and will not be opened as it is in other browsers.