### PR TITLE
Fix module.is.onScreen returns wrong result when context is changed

### DIFF
--- a/dist/components/dropdown.js
+++ b/dist/components/dropdown.js
@@ -3211,6 +3211,7 @@ $.fn.dropdown = function(parameters) {
             calculations = {
               context: {
                 scrollTop : $context.scrollTop(),
+                offset    : $context.get(0) !== window ? $context.offset() : 0,
                 height    : $context.outerHeight()
               },
               menu : {
@@ -3222,8 +3223,8 @@ $.fn.dropdown = function(parameters) {
               calculations.menu.offset.top += calculations.context.scrollTop;
             }
             onScreen = {
-              above : (calculations.context.scrollTop) <= calculations.menu.offset.top - calculations.menu.height,
-              below : (calculations.context.scrollTop + calculations.context.height) >= calculations.menu.offset.top + calculations.menu.height
+              above : (calculations.context.scrollTop) <= calculations.menu.offset.top - calculations.context.offset.top - calculations.menu.height,
+              below : (calculations.context.scrollTop + calculations.context.height) >= calculations.menu.offset.top - calculations.context.offset.top + calculations.menu.height
             };
             if(onScreen.below) {
               module.verbose('Dropdown can fit in context downward', onScreen);

--- a/dist/semantic.js
+++ b/dist/semantic.js
@@ -7568,7 +7568,7 @@ $.fn.dropdown = function(parameters) {
             calculations = {
               context: {
                 scrollTop : $context.scrollTop(),
-                offset    : $context.offset(),
+                offset    : $context.get(0) !== window ? $context.offset() : 0,
                 height    : $context.outerHeight()
               },
               menu : {

--- a/dist/semantic.js
+++ b/dist/semantic.js
@@ -7568,6 +7568,7 @@ $.fn.dropdown = function(parameters) {
             calculations = {
               context: {
                 scrollTop : $context.scrollTop(),
+                offset    : $context.offset(),
                 height    : $context.outerHeight()
               },
               menu : {
@@ -7579,8 +7580,8 @@ $.fn.dropdown = function(parameters) {
               calculations.menu.offset.top += calculations.context.scrollTop;
             }
             onScreen = {
-              above : (calculations.context.scrollTop) <= calculations.menu.offset.top - calculations.menu.height,
-              below : (calculations.context.scrollTop + calculations.context.height) >= calculations.menu.offset.top + calculations.menu.height
+              above : (calculations.context.scrollTop) <= calculations.menu.offset.top - calculations.context.offset.top - calculations.menu.height,
+              below : (calculations.context.scrollTop + calculations.context.height) >= calculations.menu.offset.top - calculations.context.offset.top + calculations.menu.height
             };
             if(onScreen.below) {
               module.verbose('Dropdown can fit in context downward', onScreen);


### PR DESCRIPTION
Fixed #5366 The dropdown menu now takes the correct offset into account by using the offset of the provided context