### PR TITLE
Fix button height bug with in menus

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -140,7 +140,7 @@
      Button
 ---------------*/
 
-.ui.menu:not(.vertical) .item > .button {
+.ui.menu:not(.vertical) .item .button {
   position: relative;
   top: @buttonOffset;
   margin: @buttonMargin;


### PR DESCRIPTION
When `.button` is not a direct descendant of `.menu` (for example, when it is wrapped), it would not get this style applied, which caused inconsistent heights of buttons that were wrapped vs. ones that weren't. Removed the `>` operator to fix this.

Refs:

- https://github.com/go-gitea/gitea/pull/3091
- https://try.gitea.io/silverwind/testcopy/commits/branch/master