### PR TITLE
#3864 Allow a validation prompt to be a function

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -354,7 +354,7 @@ $.fn.form = function(parameters) {
             var
               ruleName      = module.get.ruleName(rule),
               ancillary     = module.get.ancillaryValue(rule),
-              prompt        = rule.prompt || settings.prompt[ruleName] || settings.text.unspecifiedRule,
+              prompt        = (typeof rule.prompt === "function" ? rule.prompt() : rule.prompt) || settings.prompt[ruleName] || settings.text.unspecifiedRule,
               requiresValue = (prompt.search('{value}') !== -1),
               requiresName  = (prompt.search('{name}') !== -1),
               $label,


### PR DESCRIPTION
Allows the validation prompt to also be a function that returns a string, as discussed in [issue #3864](https://github.com/Semantic-Org/Semantic-UI/issues/3864)