### PR TITLE
Use configured lookupFields in search 'get result'

### DIFF
--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -424,8 +424,7 @@ $.fn.search = function(parameters) {
           },
           result: function(value, results) {
             var
-              lookupFields = ['title', 'id'],
-              result       = false
+              result = false
             ;
             value = (value !== undefined)
               ? value
@@ -439,7 +438,7 @@ $.fn.search = function(parameters) {
               module.debug('Finding result that matches', value);
               $.each(results, function(index, category) {
                 if($.isArray(category.results)) {
-                  result = module.search.object(value, category.results, lookupFields)[0];
+                  result = module.search.object(value, category.results)[0];
                   // don't continue searching if a result is found
                   if(result) {
                     return false;
@@ -449,7 +448,7 @@ $.fn.search = function(parameters) {
             }
             else {
               module.debug('Finding result in results object', value);
-              result = module.search.object(value, results, lookupFields)[0];
+              result = module.search.object(value, results)[0];
             }
             return result || false;
           },


### PR DESCRIPTION
Configuring the lookupFields is a core part of the search module configuration. `get result` was not respecting that and had the default hard-coded. As all it does is pass the value through to the `search object` method (where it is an optional argument), I simply removed the reference.

Failing case: https://jsfiddle.net/15xd2e41/1/
Working case: https://jsfiddle.net/ozcwbcf3/1/