### PR TITLE
[Popup] Use @background value for arrow background color

### DIFF
--- a/src/themes/default/modules/popup.variables
+++ b/src/themes/default/modules/popup.variables
@@ -43,7 +43,7 @@
 @border: @borderWidth solid @borderColor;
 
 /* Arrow */
-@arrowBackground: @white;
+@arrowBackground: @background;
 @arrowZIndex: 2;
 @arrowJitter: 0.05em;
 @arrowOffset: -(@arrowSize / 2) + @arrowJitter;


### PR DESCRIPTION
To customize Popup color you have to explicitly set both `@background` and `@arrowBackground` variables.

In most cases arrow color should match popup background color.