### PR TITLE
Changed gulp-clone version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ nbproject
 *.sublime-project
 *.sublime-workspace
 .build*
+.idea

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -4,7 +4,7 @@
 
 **Hotfix** (2)
 - **Install** - Some interactive install script issues may be fixed. Forked `gulp-prompt` plugin to allow for updated `inquirer` version
-- **Build Tools** - Fixes typo causing fix for build tools to fail [#5391](https://github.com/Semantic-Org/Semantic-UI/issues/5597) [#5590](https://github.com/Semantic-Org/Semantic-UI/issues/5391)
+- **Build Tools** - Fixes typo causing fix for build tools to fail [#5391](https://github.com/Semantic-Org/Semantic-UI/issues/5391) 
 
 ### Version 2.2.12 - Aug 07, 2017
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^4.0.0",
     "gulp-chmod": "^2.0.0",
-    "gulp-clone": "^1.0.0",
+    "gulp-clone": "1.0.0",
     "gulp-concat": "^2.6.1",
     "gulp-concat-css": "^2.3.0",
     "gulp-copy": "1.0.0",


### PR DESCRIPTION
Changed the gulp-clone version to `1.0.0` to fix #6067 
Added .`idea` directory to `.gitignore` for PhpStorm and WebStorm users