### PR TITLE
fix build/css.js, so gulp build can generate css files successfully

### DIFF
--- a/tasks/build/css.js
+++ b/tasks/build/css.js
@@ -96,7 +96,7 @@ module.exports = function(callback) {
   ;
 
   // compressed component css
-  compressedStream = stream
+  compressedStream
     .pipe(plumber())
     .pipe(clone())
     .pipe(replace(assets.source, assets.compressed))


### PR DESCRIPTION
By default, "compressedStream" should be like a function. But it's not.
So I failed to build-css.
This way I can gulp build-css successfully.

Please take a glance.
Thanks a lot.
And appreciate for all your great work on Semantic-ui, I really like it !