### PR TITLE
Fix for #5733

### DIFF
--- a/src/definitions/modules/dimmer.less
+++ b/src/definitions/modules/dimmer.less
@@ -122,6 +122,10 @@
   transform-origin: center center;
 }
 
+.ui.page.dimmer.modals {
+  perspective: none;
+}
+
 body.animating.in.dimmable,
 body.dimmed.dimmable {
   overflow: hidden;


### PR DESCRIPTION
There is an issue with scrolling content modal's scrollbar on some versions of Firefox and particular OS. To fix this issue, I have removed the perspective property for appropriate selector.