### PR TITLE
Add missing comma: makes 9 global vars local

### DIFF
--- a/tasks/admin/components/init.js
+++ b/tasks/admin/components/init.js
@@ -65,7 +65,7 @@ module.exports = function(callback) {
     }
 
     var
-      component            = release.components[index]
+      component            = release.components[index],
       outputDirectory      = path.resolve(release.outputRoot + component),
       capitalizedComponent = component.charAt(0).toUpperCase() + component.slice(1),
       repoName             = release.componentRepoRoot + capitalizedComponent,


### PR DESCRIPTION
This PR fixes a simple typo with significant consequences.

The missing colon at the end of line 68 causes implicit semicolon
insertion to happen, this ends the variable declaration statement that
starts on line 67. The nine assignments on the 69-79 then becomes
assignments to global variables.


I found this error with automatic analysis of your project:

https://lgtm.com/projects/g/Semantic-Org/Semantic-UI/snapshot/afe18811db795be24bdb23ca99b22ac2fa948aad/files/tasks/admin/components/init.js?sort=name&dir=ASC&mode=heatmap&excluded=false

You can see more (less serious) errors here: https://lgtm.com/projects/g/Semantic-Org/Semantic-UI/alerts

(full disclosure: I work for lgtm.com)