### PR TITLE
Revert "'on: change' causes error prompts to appear when blurring field "

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -358,7 +358,7 @@ $.fn.form = function(parameters) {
                   module.validate.field( validationRules );
                 }
               }
-              else if(settings.on == 'blur') {
+              else if(settings.on == 'blur' || settings.on == 'change') {
                 if(validationRules) {
                   module.validate.field( validationRules );
                 }


### PR DESCRIPTION
Reverts Semantic-Org/Semantic-UI#4423