### PR TITLE
Setup stalebot for stale issue management

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,22 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 90
+
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 30
+
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+
+# Label to use when marking an issue as stale
+staleLabel: stale
+
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed in 30 days if no further activity occurs.
+  Thank you for your contributions.
+
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -6,8 +6,8 @@ daysUntilClose: 30
 
 # Issues with these labels will never be considered stale
 exemptLabels:
-  - pinned
-  - security
+  - Confirmed Bug
+  - Needs Milestone
 
 # Label to use when marking an issue as stale
 staleLabel: stale


### PR DESCRIPTION
This PR adds the config for [stalebot](https://github.com/probot/stale).  This was agreed in the [recent conversation](https://github.com/Semantic-Org/Semantic-UI/issues/6109#issuecomment-366872453) about how to help move things forward.

I've set issues to be marked stale at 90 days of no activity and closed if no activity persists for 30 more days.

We've been using stalebot with this config over at SUIR for a while and it is going well.