### PR TITLE
Fix for #6186. Card word wrap.

### DIFF
--- a/src/definitions/views/card.less
+++ b/src/definitions/views/card.less
@@ -152,6 +152,7 @@
   box-shadow: @contentBoxShadow;
   font-size: @contentFontSize;
   border-radius: @contentBorderRadius;
+  word-wrap: break-word;
 }
 
 .ui.cards > .card > .content:after,


### PR DESCRIPTION
Fixed word-wrapping for long words without spaces (example: rsa key).