### PR TITLE
A fluid dropdown should be fluid

### DIFF
--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -1188,7 +1188,7 @@ select.ui.dropdown {
 
 .ui.fluid.dropdown {
   display: block;
-  width: 100%;
+  width: 100% !important;
   min-width: 0em;
 }
 .ui.fluid.dropdown > .dropdown.icon {


### PR DESCRIPTION
When we have a `.fluid.dropdown` inside of `.inline.fields` the dropdown is set to `auto` because of the `.inline.fields`
A fluid dropdown should always be 100%

This is an example
The dropdown should take all the red space but it does not
https://jsfiddle.net/dq9urpzn/8/