### PR TITLE
Fix #3486: [Menu] Pointing tip color in inverted pointing menu

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -1844,6 +1844,42 @@ Floated Menu / Item
   background-color: @arrowVerticalSubMenuColor;
 }
 
+.ui.inverted.pointing.menu .red.active.item:after {
+  background-color: @red !important;
+}
+.ui.inverted.pointing.menu .orange.active.item:after {
+  background-color: @orange !important;
+}
+.ui.inverted.pointing.menu .yellow.active.item:after {
+  background-color: @yellow !important;
+}
+.ui.inverted.pointing.menu .olive.active.item:after {
+  background-color: @olive !important;
+}
+.ui.inverted.pointing.menu .green.active.item:after {
+  background-color: @green !important;
+}
+.ui.inverted.pointing.menu .teal.active.item:after {
+  background-color: @teal !important;
+}
+.ui.inverted.pointing.menu .blue.active.item:after {
+  background-color: @blue !important;
+}
+.ui.inverted.pointing.menu .violet.active.item:after {
+  background-color: @violet !important;
+}
+.ui.inverted.pointing.menu .purple.active.item:after {
+  background-color: @purple !important;
+}
+.ui.inverted.pointing.menu .pink.active.item:after {
+  background-color: @pink !important;
+}
+.ui.inverted.pointing.menu .brown.active.item:after {
+  background-color: @brown !important;
+}
+.ui.inverted.pointing.menu .grey.active.item:after {
+  background-color: @grey !important;
+}
 
 
 /*--------------


### PR DESCRIPTION
### Closed Issues
#3486 

### Description

Currently, pointing tips of `.active.item` in `.inverted.pointing.menu` are all black. Those looks incosistent to tips in non-inverted pointing menu. 
![before](https://user-images.githubusercontent.com/127635/36637962-8341202e-1a2a-11e8-824a-48096e3792fe.gif)

This PR lets pointing tips can reflect a color of parent (`.active.item`), when those are in `.inverted.pointing.menu`.
![after](https://user-images.githubusercontent.com/127635/36637963-8364b46c-1a2a-11e8-8c73-a9f8dae28203.gif)

### Testcase
https://jsfiddle.net/z0vzw26e/3/
