### PR TITLE
[Popup] Respect the closable option for all kinds of popups, not just those with on='click'

### DIFF
--- a/src/definitions/modules/popup.js
+++ b/src/definitions/modules/popup.js
@@ -1015,7 +1015,7 @@ $.fn.popup = function(parameters) {
             if(settings.on == 'hover' && openedWithTouch) {
               module.bind.touchClose();
             }
-            if(settings.on == 'click' && settings.closable) {
+            if(settings.closable) {
               module.bind.clickaway();
             }
           },


### PR DESCRIPTION
The 'closable' option is useful for other kinds of popups, too, not just those automatically opened with on='click'. For example I use 'manual' popups in a React app, and having the popup code automatically deal with clicks anywhere on the page to close is a very useful thing. I was surprised it didn't work, and then I checked the source.

The "closable" option should IMHO be independent of all other popup options (this is what this pull request implements). If not, at the very least it should also work for 'manual'.

I have a corresponding (tiny) pull request for Semantic-UI-Docs, if this one is accepted.