### PR TITLE
[Popup] Fix a white space property in tooltip

### DIFF
--- a/src/definitions/modules/popup.less
+++ b/src/definitions/modules/popup.less
@@ -107,7 +107,7 @@
   position: absolute;
   text-transform: none;
   text-align: left;
-  white-space: nowrap;
+  white-space: normal;
 
   font-size: @tooltipFontSize;
 


### PR DESCRIPTION
### Closed Issues
#4187 

### Description
I found tooltip is not fully visible when tooltip has many contents. This is caused by selecting "nowrap" property as white-space in tooltip after element. So, I changed white-space property into "normal" from "nowrap".

### Testcase

#### Before
<img width="1067" alt="before" src="https://user-images.githubusercontent.com/5153062/37085921-a57328f6-2239-11e8-80f8-ee40986b71df.png">

https://jsfiddle.net/ca0rovs3/271/

#### After
<img width="1068" alt="after" src="https://user-images.githubusercontent.com/5153062/37085934-b3b390f4-2239-11e8-8f99-33778352527b.png">

https://jsfiddle.net/ca0rovs3/272/