### PR TITLE
[Menu] Disabled menu items still changing state on hover

### DIFF
--- a/src/definitions/collections/menu.less
+++ b/src/definitions/collections/menu.less
@@ -452,9 +452,9 @@
 
 .ui.menu .item.disabled,
 .ui.menu .item.disabled:hover {
-  cursor: default;
+  cursor: default !important;
   background-color: transparent !important;
-  color: @disabledTextColor;
+  color: @disabledTextColor !important;
 }
 
 


### PR DESCRIPTION
### Closed Issues

 #6147

### Description

Previously, a disabled item in a ui.menu.secondary would still change state when hovered over.

This PR makes the relevant tags important, preventing this from happening

### Testcase

[Before](https://jsfiddle.net/awei01/xho6Lxv9/)

[Fixed](https://jsfiddle.net/tcmal/j4vh2o48/4/)