### PR TITLE
[Card] Add .inverted variation to the card component 

### DIFF
--- a/examples/components/card.html
+++ b/examples/components/card.html
@@ -308,6 +308,139 @@
     </div>
   </div>
 </div>
-
+<div class="ui ten cards">
+  <div class="red card">
+    <div class="content">
+      Red card
+    </div>
+  </div>
+  <div class="orange card">
+    <div class="content">
+      Orange card
+    </div>
+  </div>
+  <div class="yellow card">
+    <div class="content">
+      Yellow card
+    </div>
+  </div>
+  <div class="olive card">
+    <div class="content">
+      Olive card
+    </div>
+  </div>
+  <div class="green card">
+    <div class="content">
+      Green card
+    </div>
+  </div>
+  <div class="teal card">
+    <div class="content">
+      Teal card
+    </div>
+  </div>
+  <div class="blue card">
+    <div class="content">
+      Blue card
+    </div>
+  </div>
+  <div class="violet card">
+    <div class="content">
+      Violet card
+    </div>
+  </div>
+  <div class="purple card">
+    <div class="content">
+      Purple card
+    </div>
+  </div>
+  <div class="pink card">
+    <div class="content">
+      Pink card
+    </div>
+  </div>
+  <div class="brown card">
+    <div class="content">
+      Brown card
+    </div>
+  </div>
+  <div class="grey card">
+    <div class="content">
+      Grey card
+    </div>
+  </div>
+  <div class="black card">
+    <div class="content">
+      Black card
+    </div>
+  </div>
+</div>
+<div class="ui ten inverted cards">
+  <div class="red card">
+    <div class="content">
+      Inverted (red) card
+    </div>
+  </div>
+  <div class="orange card">
+    <div class="content">
+      Inverted (orange) card
+    </div>
+  </div>
+  <div class="yellow card">
+    <div class="content">
+      Inverted (yellow) card
+    </div>
+  </div>
+  <div class="olive card">
+    <div class="content">
+      Inverted (olive) card
+    </div>
+  </div>
+  <div class="green card">
+    <div class="content">
+      Inverted (green) card
+    </div>
+  </div>
+  <div class="teal card">
+    <div class="content">
+      Inverted (teal) card
+    </div>
+  </div>
+  <div class="blue card">
+    <div class="content">
+      Inverted (blue) card
+    </div>
+  </div>
+  <div class="violet card">
+    <div class="content">
+      Inverted (violet) card
+    </div>
+  </div>
+  <div class="purple card">
+    <div class="content">
+      Inverted (purple) card
+    </div>
+  </div>
+  <div class="pink card">
+    <div class="content">
+      Inverted (pink) card
+    </div>
+  </div>
+  <div class="brown card">
+    <div class="content">
+      Inverted (brown) card
+    </div>
+  </div>
+  <div class="grey card">
+    <div class="content">
+      Inverted (grey) card
+    </div>
+  </div>
+  <div class="black card">
+    <div class="content">
+      Inverted (black) card
+    </div>
+  </div>
+</div>
 </body>
 </html>

--- a/src/definitions/views/card.less
+++ b/src/definitions/views/card.less
@@ -543,8 +543,8 @@ a.ui.card:hover,
 --------------------*/
 
 /* Red */
-.ui.red.cards > .card:not(.inverted),
-.ui.cards > .red.card:not(.inverted),
+.ui.red.cards:not(.inverted) > .card:not(.inverted),
+.ui.cards:not(.inverted) > .red.card:not(.inverted),
 .ui.red.card:not(.inverted) {
   box-shadow:
     @borderShadow,
@@ -552,8 +552,8 @@ a.ui.card:hover,
     @shadowBoxShadow
   ;
 }
-.ui.red.cards > .card:not(.inverted):hover,
-.ui.cards > .red.card:not(.inverted):hover,
+.ui.red.cards:not(.inverted) > .card:not(.inverted):hover,
+.ui.cards:not(.inverted) > .red.card:not(.inverted):hover,
 .ui.red.card:not(.inverted):hover {
   box-shadow:
     @borderShadow,
@@ -572,18 +572,18 @@ a.ui.card:hover,
 }
 
 /* Orange */
-.ui.orange.cards > .card,
-.ui.cards > .orange.card,
-.ui.orange.card {
+.ui.orange.cards:not(.inverted) > .card:not(.inverted),
+.ui.cards:not(.inverted) > .orange.card:not(.inverted),
+.ui.orange.card:not(.inverted) {
   box-shadow:
     @borderShadow,
     0px @coloredShadowDistance 0px 0px @orange,
     @shadowBoxShadow
   ;
 }
-.ui.orange.cards > .card:hover,
-.ui.cards > .orange.card:hover,
-.ui.orange.card:hover {
+.ui.orange.cards:not(.inverted) > .card:not(.inverted):hover,
+.ui.cards::not(.inverted) > .orange.card:not(.inverted):hover,
+.ui.orange.card:not(.inverted):hover {
   box-shadow:
     @borderShadow,
     0px @coloredShadowDistance 0px 0px @orangeHover,
@@ -601,9 +601,9 @@ a.ui.card:hover,
 }
 
 /* Yellow */
-.ui.yellow.cards > .card,
-.ui.cards > .yellow.card,
-.ui.yellow.card {
+.ui.yellow.cards:not(.inverted) > .card:not(.inverted),
+.ui.cards:not(.inverted) > .yellow.card:not(.inverted),
+.ui.yellow.card:not(.inverted) {
   box-shadow:
     @borderShadow,
     0px @coloredShadowDistance 0px 0px @yellow,
@@ -611,9 +611,9 @@ a.ui.card:hover,
   ;
 }
 
-.ui.yellow.cards > .card:hover,
-.ui.cards > .yellow.card:hover,
-.ui.yellow.card:hover {
+.ui.yellow.cards:not(.inverted) > .card:not(.inverted):hover,
+.ui.cards:not(.inverted) > .yellow.card:not(.inverted):hover,
+.ui.yellow.card:not(.inverted):hover {
   box-shadow:
     @borderShadow,
     0px @coloredShadowDistance 0px 0px @yellowHover,
@@ -631,9 +631,9 @@ a.ui.card:hover,
 }
 
 /* Olive */
-.ui.olive.cards > .card,
-.ui.cards > .olive.card,
-.ui.olive.card {
+.ui.olive.cards:not(.inverted) > .card:not(.inverted),
+.ui.cards:not(.inverted) > .olive.card:not(.inverted),
+.ui.olive.card:not(.inverted) {
   box-shadow:
     @borderShadow,
     0px @coloredShadowDistance 0px 0px @olive,
@@ -641,9 +641,9 @@ a.ui.card:hover,
   ;
 }
 
-.ui.olive.cards > .card:hover,
-.ui.cards > .olive.card:hover,
-.ui.olive.card:hover {
+.ui.olive.cards:not(.inverted) > .card:not(.inverted):hover,
+.ui.cards:not(.inverted) > .olive.card:not(.inverted):hover,
+.ui.olive.card:not(.inverted):hover {
   box-shadow:
     @borderShadow,
     0px @coloredShadowDistance 0px 0px @oliveHover,
@@ -661,18 +661,18 @@ a.ui.card:hover,
 }
 
 /* Green */
-.ui.green.cards > .card,
-.ui.cards > .green.card,
-.ui.green.card {
+.ui.green.cards:not(.inverted) > .card:not(.inverted),
+.ui.cards:not(.inverted) > .green.card:not(.inverted),
+.ui.green.card:not(.inverted) {
   box-shadow:
     @borderShadow,
     0px @coloredShadowDistance 0px 0px @green,
     @shadowBoxShadow
   ;
 }
-.ui.green.cards > .card:hover,
-.ui.cards > .green.card:hover,
-.ui.green.card:hover {
+.ui.green.cards:not(.inverted) > .card:not(.inverted):hover,
+.ui.cards:not(.inverted) > .green.card:not(.inverted):hover,
+.ui.green.card:not(.inverted):hover {
   box-shadow:
     @borderShadow,
     0px @coloredShadowDistance 0px 0px @greenHover,
@@ -690,18 +690,18 @@ a.ui.card:hover,
 }
 
 /* Teal */
-.ui.teal.cards > .card,
-.ui.cards > .teal.card,
-.ui.teal.card {
+.ui.teal.cards:not(.inverted) > .card:not(.inverted),
+.ui.cards:not(.inverted) > .teal.card:not(.inverted),
+.ui.teal.card:not(.inverted) {
   box-shadow:
     @borderShadow,
     0px @coloredShadowDistance 0px 0px @teal,
     @shadowBoxShadow
   ;
 }
-.ui.teal.cards > .card:hover,
-.ui.cards > .teal.card:hover,
-.ui.teal.card:hover {
+.ui.teal.cards:not(.inverted) > .card:not(.inverted):hover,
+.ui.cards:not(.inverted) > .teal.card:not(.inverted):hover,
+.ui.teal.card:not(.inverted):hover {
   box-shadow:
     @borderShadow,
     0px @coloredShadowDistance 0px 0px @tealHover,
@@ -719,18 +719,18 @@ a.ui.card:hover,
 }
 
 /* Blue */
-.ui.blue.cards > .card,
-.ui.cards > .blue.card,
-.ui.blue.card {
+.ui.blue.cards:not(.inverted) > .card:not(.inverted),
+.ui.cards:not(.inverted) > .blue.card:not(.inverted),
+.ui.blue.card:not(.inverted) {
   box-shadow:
     @borderShadow,
     0px @coloredShadowDistance 0px 0px @blue,
     @shadowBoxShadow
   ;
 }
-.ui.blue.cards > .card:hover,
-.ui.cards > .blue.card:hover,
-.ui.blue.card:hover {
+.ui.blue.cards:not(.inverted) > .card:not(.inverted):hover,
+.ui.cards:not(.inverted) > .blue.card:not(.inverted):hover,
+.ui.blue.card:not(.inverted):hover {
   box-shadow:
     @borderShadow,
     0px @coloredShadowDistance 0px 0px @blueHover,
@@ -748,18 +748,18 @@ a.ui.card:hover,
 }
 
 /* Violet */
-.ui.violet.cards > .card,
-.ui.cards > .violet.card,
-.ui.violet.card {
+.ui.violet.cards:not(.inverted) > .card:not(.inverted),
+.ui.cards:not(.inverted) > .violet.card:not(.inverted),
+.ui.violet.card:not(.inverted) {
   box-shadow:
     @borderShadow,
     0px @coloredShadowDistance 0px 0px @violet,
     @shadowBoxShadow
   ;
 }
-.ui.violet.cards > .card:hover,
-.ui.cards > .violet.card:hover,
-.ui.violet.card:hover {
+.ui.violet.cards:not(.inverted) > .card:not(.inverted):hover,
+.ui.cards:not(.inverted) > .violet.card:not(.inverted):hover,
+.ui.violet.card:not(.inverted):hover {
   box-shadow:
     @borderShadow,
     0px @coloredShadowDistance 0px 0px @violetHover,
@@ -777,18 +777,18 @@ a.ui.card:hover,
 }
 
 /* Purple */
-.ui.purple.cards > .card,
-.ui.cards > .purple.card,
-.ui.purple.card {
+.ui.purple.cards:not(.inverted) > .card:not(.inverted),
+.ui.cards:not(.inverted) > .purple.card:not(.inverted),
+.ui.purple.card:not(.inverted) {
   box-shadow:
     @borderShadow,
     0px @coloredShadowDistance 0px 0px @purple,
     @shadowBoxShadow
   ;
 }
-.ui.purple.cards > .card:hover,
-.ui.cards > .purple.card:hover,
-.ui.purple.card:hover {
+.ui.purple.cards:not(.inverted) > .card:not(.inverted):hover,
+.ui.cards:not(.inverted) > .purple.card:not(.inverted):hover,
+.ui.purple.card:not(.inverted):hover {
   box-shadow:
     @borderShadow,
     0px @coloredShadowDistance 0px 0px @purpleHover,
@@ -806,18 +806,18 @@ a.ui.card:hover,
 }
 
 /* Pink */
-.ui.pink.cards > .card,
-.ui.cards > .pink.card,
-.ui.pink.card {
+.ui.pink.cards:not(.inverted) > .card:not(.inverted),
+.ui.cards:not(.inverted) > .pink.card:not(.inverted),
+.ui.pink.card:not(.inverted) {
   box-shadow:
     @borderShadow,
     0px @coloredShadowDistance 0px 0px @pink,
     @shadowBoxShadow
   ;
 }
-.ui.pink.cards > .card:hover,
-.ui.cards > .pink.card:hover,
-.ui.pink.card:hover {
+.ui.pink.cards:not(.inverted) > .card:not(.inverted):hover,
+.ui.cards:not(.inverted) > .pink.card:not(.inverted):hover,
+.ui.pink.card:not(.inverted):hover {
   box-shadow:
     @borderShadow,
     0px @coloredShadowDistance 0px 0px @pinkHover,
@@ -835,18 +835,18 @@ a.ui.card:hover,
 }
 
 /* Brown */
-.ui.brown.cards > .card,
-.ui.cards > .brown.card,
-.ui.brown.card {
+.ui.brown.cards:not(.inverted) > .card:not(.inverted),
+.ui.cards:not(.inverted) > .brown.card:not(.inverted),
+.ui.brown.card:not(.inverted) {
   box-shadow:
     @borderShadow,
     0px @coloredShadowDistance 0px 0px @brown,
     @shadowBoxShadow
   ;
 }
-.ui.brown.cards > .card:hover,
-.ui.cards > .brown.card:hover,
-.ui.brown.card:hover {
+.ui.brown.cards:not(.inverted) > .card:not(.inverted):hover,
+.ui.cards:not(.inverted) > .brown.card:not(.inverted):hover,
+.ui.brown.card:not(.inverted):hover {
   box-shadow:
     @borderShadow,
     0px @coloredShadowDistance 0px 0px @brownHover,
@@ -864,18 +864,18 @@ a.ui.card:hover,
 }
 
 /* Grey */
-.ui.grey.cards > .card,
-.ui.cards > .grey.card,
-.ui.grey.card {
+.ui.grey.cards:not(.inverted) > .card:not(.inverted),
+.ui.cards:not(.inverted) > .grey.card:not(.inverted),
+.ui.grey.card:not(.inverted) {
   box-shadow:
     @borderShadow,
     0px @coloredShadowDistance 0px 0px @grey,
     @shadowBoxShadow
   ;
 }
-.ui.grey.cards > .card:hover,
-.ui.cards > .grey.card:hover,
-.ui.grey.card:hover {
+.ui.grey.cards:not(.inverted) > .card:not(.inverted):hover,
+.ui.cards:not(.inverted) > .grey.card:not(.inverted):hover,
+.ui.grey.card:not(.inverted):hover {
   box-shadow:
     @borderShadow,
     0px @coloredShadowDistance 0px 0px @greyHover,
@@ -893,18 +893,18 @@ a.ui.card:hover,
 }
 
 /* Black */
-.ui.black.cards > .card,
-.ui.cards > .black.card,
-.ui.black.card {
+.ui.black.cards:not(.inverted) > .card:not(.inverted),
+.ui.cards:not(.inverted) > .black.card:not(.inverted),
+.ui.black.card:not(.inverted) {
   box-shadow:
     @borderShadow,
     0px @coloredShadowDistance 0px 0px @black,
     @shadowBoxShadow
   ;
 }
-.ui.black.cards > .card:hover,
-.ui.cards > .black.card:hover,
-.ui.black.card:hover {
+.ui.black.cards:not(.inverted) > .card:not(.inverted):hover,
+.ui.cards:not(.inverted) > .black.card:not(.inverted):hover,
+.ui.black.card:not(.inverted):hover {
   box-shadow:
     @borderShadow,
     0px @coloredShadowDistance 0px 0px @blackHover,

--- a/src/definitions/views/card.less
+++ b/src/definitions/views/card.less
@@ -172,6 +172,11 @@
   color: @headerColor;
 }
 
+.ui.cards.inverted > .card > .content > .header,
+.ui.card.inverted > .content > .header {
+  color: @white;
+}
+
 /* Default Header Size */
 .ui.cards > .card > .content > .header:not(.ui),
 .ui.card > .content > .header:not(.ui) {

--- a/src/definitions/views/card.less
+++ b/src/definitions/views/card.less
@@ -489,23 +489,32 @@ a.ui.card:hover,
 --------------------*/
 
 /* Red */
-.ui.red.cards > .card,
-.ui.cards > .red.card,
-.ui.red.card {
+.ui.red.cards > .card:not(.inverted),
+.ui.cards > .red.card:not(.inverted),
+.ui.red.card:not(.inverted) {
   box-shadow:
     @borderShadow,
     0px @coloredShadowDistance 0px 0px @red,
     @shadowBoxShadow
   ;
 }
-.ui.red.cards > .card:hover,
-.ui.cards > .red.card:hover,
-.ui.red.card:hover {
+.ui.red.cards > .card:not(.inverted):hover,
+.ui.cards > .red.card:not(.inverted):hover,
+.ui.red.card:not(.inverted):hover {
   box-shadow:
     @borderShadow,
     0px @coloredShadowDistance 0px 0px @redHover,
     @shadowHoverBoxShadow
   ;
+}
+
+.ui.red.cards > .card.inverted,
+.ui.red.cards.inverted > .card,
+.ui.cards > .red.card.inverted,
+.ui.cards.inverted > .red.card,
+.ui.red.card.inverted {
+  background-color: @red !important;
+  color: @white !important;
 }
 
 /* Orange */
@@ -528,6 +537,15 @@ a.ui.card:hover,
   ;
 }
 
+.ui.orange.cards > .card.inverted,
+.ui.orange.cards.inverted > .card,
+.ui.cards > .orange.card.inverted,
+.ui.cards.inverted > .orange.card,
+.ui.orange.card.inverted {
+  background-color: @orange !important;
+  color: @white !important;
+}
+
 /* Yellow */
 .ui.yellow.cards > .card,
 .ui.cards > .yellow.card,
@@ -538,6 +556,7 @@ a.ui.card:hover,
     @shadowBoxShadow
   ;
 }
+
 .ui.yellow.cards > .card:hover,
 .ui.cards > .yellow.card:hover,
 .ui.yellow.card:hover {
@@ -546,6 +565,15 @@ a.ui.card:hover,
     0px @coloredShadowDistance 0px 0px @yellowHover,
     @shadowHoverBoxShadow
   ;
+}
+
+.ui.yellow.cards > .card.inverted,
+.ui.yellow.cards.inverted > .card,
+.ui.cards > .yellow.card.inverted,
+.ui.cards.inverted > .yellow.card,
+.ui.yellow.card.inverted {
+  background-color: @yellow !important;
+  color: @white !important;
 }
 
 /* Olive */
@@ -558,6 +586,7 @@ a.ui.card:hover,
     @shadowBoxShadow
   ;
 }
+
 .ui.olive.cards > .card:hover,
 .ui.cards > .olive.card:hover,
 .ui.olive.card:hover {
@@ -566,6 +595,15 @@ a.ui.card:hover,
     0px @coloredShadowDistance 0px 0px @oliveHover,
     @shadowHoverBoxShadow
   ;
+}
+
+.ui.olive.cards > .card.inverted,
+.ui.olive.cards.inverted > .card,
+.ui.cards > .olive.card.inverted,
+.ui.cards.inverted > .olive.card,
+.ui.olive.card.inverted {
+  background-color: @olive !important;
+  color: @white !important;
 }
 
 /* Green */
@@ -588,6 +626,15 @@ a.ui.card:hover,
   ;
 }
 
+.ui.green.cards > .card.inverted,
+.ui.green.cards.inverted > .card,
+.ui.cards > .green.card.inverted,
+.ui.cards.inverted > .green.card,
+.ui.green.card.inverted {
+  background-color: @green !important;
+  color: @white !important;
+}
+
 /* Teal */
 .ui.teal.cards > .card,
 .ui.cards > .teal.card,
@@ -606,6 +653,15 @@ a.ui.card:hover,
     0px @coloredShadowDistance 0px 0px @tealHover,
     @shadowHoverBoxShadow
   ;
+}
+
+.ui.teal.cards > .card.inverted,
+.ui.teal.cards.inverted > .card,
+.ui.cards > .teal.card.inverted,
+.ui.cards.inverted > .teal.card,
+.ui.teal.card.inverted {
+  background-color: @teal !important;
+  color: @white !important;
 }
 
 /* Blue */
@@ -628,6 +684,15 @@ a.ui.card:hover,
   ;
 }
 
+.ui.blue.cards > .card.inverted,
+.ui.blue.cards.inverted > .card,
+.ui.cards > .blue.card.inverted,
+.ui.cards.inverted > .blue.card,
+.ui.blue.card.inverted {
+  background-color: @blue !important;
+  color: @white !important;
+}
+
 /* Violet */
 .ui.violet.cards > .card,
 .ui.cards > .violet.card,
@@ -646,6 +711,15 @@ a.ui.card:hover,
     0px @coloredShadowDistance 0px 0px @violetHover,
     @shadowHoverBoxShadow
   ;
+}
+
+.ui.violet.cards > .card.inverted,
+.ui.violet.cards.inverted > .card,
+.ui.cards > .violet.card.inverted,
+.ui.cards.inverted > .violet.card,
+.ui.violet.card.inverted {
+  background-color: @violet !important;
+  color: @white !important;
 }
 
 /* Purple */
@@ -668,6 +742,15 @@ a.ui.card:hover,
   ;
 }
 
+.ui.purple.cards > .card.inverted,
+.ui.purple.cards.inverted > .card,
+.ui.cards > .purple.card.inverted,
+.ui.cards.inverted > .purple.card,
+.ui.purple.card.inverted {
+  background-color: @purple !important;
+  color: @white !important;
+}
+
 /* Pink */
 .ui.pink.cards > .card,
 .ui.cards > .pink.card,
@@ -686,6 +769,15 @@ a.ui.card:hover,
     0px @coloredShadowDistance 0px 0px @pinkHover,
     @shadowHoverBoxShadow
   ;
+}
+
+.ui.pink.cards > .card.inverted,
+.ui.pink.cards.inverted > .card,
+.ui.cards > .pink.card.inverted,
+.ui.cards.inverted > .pink.card,
+.ui.pink.card.inverted {
+  background-color: @pink !important;
+  color: @white !important;
 }
 
 /* Brown */
@@ -708,6 +800,15 @@ a.ui.card:hover,
   ;
 }
 
+.ui.brown.cards > .card.inverted,
+.ui.brown.cards.inverted > .card,
+.ui.cards > .brown.card.inverted,
+.ui.cards.inverted > .brown.card,
+.ui.brown.card.inverted {
+  background-color: @brown !important;
+  color: @white !important;
+}
+
 /* Grey */
 .ui.grey.cards > .card,
 .ui.cards > .grey.card,
@@ -728,6 +829,15 @@ a.ui.card:hover,
   ;
 }
 
+.ui.grey.cards > .card.inverted,
+.ui.grey.cards.inverted > .card,
+.ui.cards > .grey.card.inverted,
+.ui.cards.inverted > .grey.card,
+.ui.grey.card.inverted {
+  background-color: @grey !important;
+  color: @white !important;
+}
+
 /* Black */
 .ui.black.cards > .card,
 .ui.cards > .black.card,
@@ -746,6 +856,15 @@ a.ui.card:hover,
     0px @coloredShadowDistance 0px 0px @blackHover,
     @shadowHoverBoxShadow
   ;
+}
+
+.ui.black.cards > .card.inverted,
+.ui.black.cards.inverted > .card,
+.ui.cards > .black.card.inverted,
+.ui.cards.inverted > .black.card,
+.ui.black.card.inverted {
+  background-color: @black !important;
+  color: @white !important;
 }
 
 /*--------------

--- a/src/definitions/views/card.less
+++ b/src/definitions/views/card.less
@@ -174,7 +174,7 @@
 
 .ui.cards.inverted > .card > .content > .header,
 .ui.card.inverted > .content > .header {
-  color: @white;
+  color: @invertedTextColor;
 }
 
 /* Default Header Size */
@@ -254,6 +254,12 @@
   color: @descriptionColor;
 }
 
+.ui.cards.inverted > .card > .content > .description,
+.ui.card.inverted > .content > .description {
+  color: @invertedTextColor !important;
+}
+
+
 /*--------------
     Paragraph
 ---------------*/
@@ -276,6 +282,11 @@
   font-size: @metaFontSize;
   color: @metaColor;
 }
+.ui.cards.inverted > .card .meta,
+.ui.card.inverted .meta {
+  color: @invertedMutedTextColor !important;
+}
+
 .ui.cards > .card .meta *,
 .ui.card .meta * {
   margin-right: @metaSpacing;
@@ -301,9 +312,19 @@
   color: @contentLinkColor;
   transition: @contentLinkTransition;
 }
-.ui.cards > .card > .content a:not(.ui):hover,
-.ui.card > .content a:not(.ui):hover {
+.ui.cards.inverted > .card > .content a:not(.ui):hover,
+.ui.card.inverted > .content a:not(.ui):hover {
   color: @contentLinkHoverColor;
+}
+
+/* Generic - Inverted */
+.ui.cards.inverted > .card > .content a:not(.ui),
+.ui.card.inverted > .content a:not(.ui) {
+  color: @invertedTextColor !important;
+}
+.ui.cards.inverted > .card > .content a:not(.ui):hover,
+.ui.card.inverted > .content a:not(.ui):hover {
+  color: @invertedHoveredTextColor !important;
 }
 
 /* Header */
@@ -316,6 +337,16 @@
   color: @headerLinkHoverColor;
 }
 
+/* Header - Inverted */
+.ui.cards.inverted > .card > .content a.header,
+.ui.card.inverted > .content a.header {
+  color: @invertedTextColor !important;
+}
+.ui.cards.inverted > .card > .content a.header:hover,
+.ui.card.inverted > .content a.header:hover {
+  color: @invertedHoveredTextColor !important;
+}
+
 /* Meta */
 .ui.cards > .card .meta > a:not(.ui),
 .ui.card .meta > a:not(.ui) {
@@ -324,6 +355,16 @@
 .ui.cards > .card .meta > a:not(.ui):hover,
 .ui.card .meta > a:not(.ui):hover {
   color: @metaLinkHoverColor;
+}
+
+/* Meta - Inverted */
+.ui.cards.inverted > .card .meta > a:not(.ui),
+.ui.card.inverted .meta > a:not(.ui) {
+  color: @invertedMutedTextColor !important;
+}
+.ui.cards.inverted > .card .meta > a:not(.ui):hover,
+.ui.card.inverted .meta > a:not(.ui):hover {
+  color: @invertedLightTextColor !important;
 }
 
 /*--------------
@@ -420,6 +461,14 @@
   color: @extraLinkHoverColor;
 }
 
+.ui.cards.inverted > .card > .extra a:not(.ui),
+.ui.card.inverted > .extra a:not(.ui) {
+  color: @invertedMutedTextColor !important;
+}
+.ui.cards.inverted > .card > .extra a:not(.ui):hover,
+.ui.card.inverted > .extra a:not(.ui):hover {
+  color: @invertedLightTextColor !important;
+}
 
 /*******************************
            Variations
@@ -519,7 +568,7 @@ a.ui.card:hover,
 .ui.cards.inverted > .red.card,
 .ui.red.card.inverted {
   background-color: @red !important;
-  color: @white !important;
+  color: @invertedTextColor !important;
 }
 
 /* Orange */
@@ -548,7 +597,7 @@ a.ui.card:hover,
 .ui.cards.inverted > .orange.card,
 .ui.orange.card.inverted {
   background-color: @orange !important;
-  color: @white !important;
+  color: @invertedTextColor !important;
 }
 
 /* Yellow */
@@ -578,7 +627,7 @@ a.ui.card:hover,
 .ui.cards.inverted > .yellow.card,
 .ui.yellow.card.inverted {
   background-color: @yellow !important;
-  color: @white !important;
+  color: @invertedTextColor !important;
 }
 
 /* Olive */
@@ -608,7 +657,7 @@ a.ui.card:hover,
 .ui.cards.inverted > .olive.card,
 .ui.olive.card.inverted {
   background-color: @olive !important;
-  color: @white !important;
+  color: @invertedTextColor !important;
 }
 
 /* Green */
@@ -637,7 +686,7 @@ a.ui.card:hover,
 .ui.cards.inverted > .green.card,
 .ui.green.card.inverted {
   background-color: @green !important;
-  color: @white !important;
+  color: @invertedTextColor !important;
 }
 
 /* Teal */
@@ -666,7 +715,7 @@ a.ui.card:hover,
 .ui.cards.inverted > .teal.card,
 .ui.teal.card.inverted {
   background-color: @teal !important;
-  color: @white !important;
+  color: @invertedTextColor !important;
 }
 
 /* Blue */
@@ -695,7 +744,7 @@ a.ui.card:hover,
 .ui.cards.inverted > .blue.card,
 .ui.blue.card.inverted {
   background-color: @blue !important;
-  color: @white !important;
+  color: @invertedTextColor !important;
 }
 
 /* Violet */
@@ -724,7 +773,7 @@ a.ui.card:hover,
 .ui.cards.inverted > .violet.card,
 .ui.violet.card.inverted {
   background-color: @violet !important;
-  color: @white !important;
+  color: @invertedTextColor !important;
 }
 
 /* Purple */
@@ -753,7 +802,7 @@ a.ui.card:hover,
 .ui.cards.inverted > .purple.card,
 .ui.purple.card.inverted {
   background-color: @purple !important;
-  color: @white !important;
+  color: @invertedTextColor !important;
 }
 
 /* Pink */
@@ -782,7 +831,7 @@ a.ui.card:hover,
 .ui.cards.inverted > .pink.card,
 .ui.pink.card.inverted {
   background-color: @pink !important;
-  color: @white !important;
+  color: @invertedTextColor !important;
 }
 
 /* Brown */
@@ -811,7 +860,7 @@ a.ui.card:hover,
 .ui.cards.inverted > .brown.card,
 .ui.brown.card.inverted {
   background-color: @brown !important;
-  color: @white !important;
+  color: @invertedTextColor !important;
 }
 
 /* Grey */
@@ -840,7 +889,7 @@ a.ui.card:hover,
 .ui.cards.inverted > .grey.card,
 .ui.grey.card.inverted {
   background-color: @grey !important;
-  color: @white !important;
+  color: @invertedTextColor !important;
 }
 
 /* Black */
@@ -869,7 +918,7 @@ a.ui.card:hover,
 .ui.cards.inverted > .black.card,
 .ui.black.card.inverted {
   background-color: @black !important;
-  color: @white !important;
+  color: @invertedTextColor !important;
 }
 
 /*--------------


### PR DESCRIPTION
### Closed Issues

#3478 

### Description

Adds an inverted variation to the card component, with a `.ui.cards > .card.inverted.red` or  `.ui.card.inverted.red` (must specify a colour, any works)

If `.inverted` is applied to a `.cards` component, all cards within that component are inverted.

Headers, meta components, content components & link components have their colours changed.

Also adds examples for these cards & non-inverted coloured cards.

### Testcase

Before, no special styling was added to `.inverted` cards.

[Inverted cards demonstration](https://jsfiddle.net/tcmal/vykrmL09/)