### PR TITLE
Fix Progress Label CSS for Inverted Indicating

### DIFF
--- a/dist/components/progress.css
+++ b/dist/components/progress.css
@@ -116,30 +116,6 @@
   background-color: #66DA81;
 }
 
-/* Indicating Label */
-.ui.indicating.progress[data-percent^="1"] .label,
-.ui.indicating.progress[data-percent^="2"] .label {
-  color: rgba(0, 0, 0, 0.87);
-}
-.ui.indicating.progress[data-percent^="3"] .label {
-  color: rgba(0, 0, 0, 0.87);
-}
-.ui.indicating.progress[data-percent^="4"] .label,
-.ui.indicating.progress[data-percent^="5"] .label {
-  color: rgba(0, 0, 0, 0.87);
-}
-.ui.indicating.progress[data-percent^="6"] .label {
-  color: rgba(0, 0, 0, 0.87);
-}
-.ui.indicating.progress[data-percent^="7"] .label,
-.ui.indicating.progress[data-percent^="8"] .label {
-  color: rgba(0, 0, 0, 0.87);
-}
-.ui.indicating.progress[data-percent^="9"] .label,
-.ui.indicating.progress[data-percent^="100"] .label {
-  color: rgba(0, 0, 0, 0.87);
-}
-
 /* Single Digits */
 .ui.indicating.progress[data-percent="1"] .bar,
 .ui.indicating.progress[data-percent="2"] .bar,
@@ -151,22 +127,6 @@
 .ui.indicating.progress[data-percent="8"] .bar,
 .ui.indicating.progress[data-percent="9"] .bar {
   background-color: #D95C5C;
-}
-.ui.indicating.progress[data-percent="1"] .label,
-.ui.indicating.progress[data-percent="2"] .label,
-.ui.indicating.progress[data-percent="3"] .label,
-.ui.indicating.progress[data-percent="4"] .label,
-.ui.indicating.progress[data-percent="5"] .label,
-.ui.indicating.progress[data-percent="6"] .label,
-.ui.indicating.progress[data-percent="7"] .label,
-.ui.indicating.progress[data-percent="8"] .label,
-.ui.indicating.progress[data-percent="9"] .label {
-  color: rgba(0, 0, 0, 0.87);
-}
-
-/* Indicating Success */
-.ui.indicating.progress.success .label {
-  color: #1A531B;
 }
 
 


### PR DESCRIPTION
https://github.com/Semantic-Org/Semantic-UI-React/issues/2672

The .ui.indicating.progress .label CSS overrides the .ui.inverted.progress CSS, leading to dark text when light is expected.  The indicating class should have no effect on the label.

This request removes the .ui.indicating.progress .label CSS, which fixes the issue.

✖ Multiple features in one PR
✖ New Components Unless Previously Discussed with Maintainers (Consider creating separate repo, I'll link out to you)

✔ Add comments to complex/confusing code in "code" view of PR
✔ BUGS → This form is required:
✔ Enhancements → Only specific enhancements with detailed descriptions.

### Issue Titles
See related issue in the Semantic UI React implementation:
https://github.com/Semantic-Org/Semantic-UI-React/issues/2672

### Testcase
https://codepen.io/anon/pen/jzwPjQ?editors=1111