### PR TITLE
Update modal.js

### DIFF
--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -609,7 +609,7 @@ $.fn.modal = function(parameters) {
                 ? $autofocus.first()
                 : $inputs.first()
             ;
-            if($input.length > 0) {
+            if($input.length > 0 && !$input.is(':focus')) {
               $input.focus();
             }
           },


### PR DESCRIPTION
FIX: Removes blink for already focused element if jquery.maskedinput plug-in is used and placeholder value exists.