### PR TITLE
[Table] Adds overflow hidden to prevent border cutoff.

### DIFF
--- a/dist/components/table.css
+++ b/dist/components/table.css
@@ -27,6 +27,7 @@
   color: rgba(0, 0, 0, 0.87);
   border-collapse: separate;
   border-spacing: 0px;
+  overflow: hidden;
 }
 .ui.table:first-child {
   margin-top: 0em;


### PR DESCRIPTION
### Closed Issues
(Didn't make an issue, happy to do so.)

### Description
When tables are with content inside the table cell, overflow can hide the border.

### Testcase
[Show before with this fiddle]
https://jsfiddle.net/ca0rovs3/449/

[After]
https://jsfiddle.net/ca0rovs3/451/

### How to reproduce

Ensure that the table has a high width in the js fiddle.
