### PR TITLE
[Dependency] Replace deprecated module gulp-util with replace-ext

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "gulp-replace": "*",
     "gulp-rtlcss": "*",
     "gulp-uglify": "*",
-    "gulp-util": "*",
     "gulp-watch": "*",
     "map-stream": "*",
     "require-dot-file": "*",
@@ -75,7 +74,6 @@
     "gulp-replace": "^0.6.1",
     "gulp-rtlcss": "^1.0.0",
     "gulp-uglify": "^3.0.0",
-    "gulp-util": "^3.0.8",
     "gulp-watch": "^4.3.11",
     "jquery": "^3.2.1",
     "map-stream": "^0.1.0",
@@ -92,7 +90,8 @@
     "gulp-debug": "*",
     "gulp-git": "*",
     "gulp-tap": "*",
-    "merge-stream": "*"
+    "merge-stream": "*",
+    "replace-ext": "^1.0.0"
   },
   "style": "dist/semantic.css"
 }

--- a/tasks/admin/components/create.js
+++ b/tasks/admin/components/create.js
@@ -34,7 +34,6 @@ var
   rename          = require('gulp-rename'),
   replace         = require('gulp-replace'),
   tap             = require('gulp-tap'),
-  util            = require('gulp-util'),
 
   // config
   config          = require('../../config/user'),

--- a/tasks/docs/serve.js
+++ b/tasks/docs/serve.js
@@ -21,7 +21,7 @@ var
   rename       = require('gulp-rename'),
   replace      = require('gulp-replace'),
   uglify       = require('gulp-uglify'),
-  util         = require('gulp-util'),
+  replaceExt   = require('replace-ext'),
   watch        = require('gulp-watch'),
 
   // user config
@@ -142,12 +142,12 @@ module.exports = function () {
       }
       else if(isPackagedTheme) {
         console.log('Change detected in packaged theme');
-        lessPath = util.replaceExtension(file.path, '.less');
+        lessPath = replaceExt(file.path, '.less');
         lessPath = lessPath.replace(tasks.regExp.theme, source.definitions);
       }
       else if(isSiteTheme) {
         console.log('Change detected in site theme');
-        lessPath = util.replaceExtension(file.path, '.less');
+        lessPath = replaceExt(file.path, '.less');
         lessPath = lessPath.replace(source.site, source.definitions);
       }
       else {

--- a/tasks/rtl/watch.js
+++ b/tasks/rtl/watch.js
@@ -22,7 +22,7 @@ var
   replace      = require('gulp-replace'),
   rtlcss       = require('gulp-rtlcss'),
   uglify       = require('gulp-uglify'),
-  util         = require('gulp-util'),
+  replaceExt   = require('replace-ext'),
   watch        = require('gulp-watch'),
 
   // user config
@@ -107,16 +107,16 @@ module.exports = function(callback) {
       else if(isPackagedTheme) {
         console.log('Change detected in packaged theme');
         lessPath = lessPath.replace(tasks.regExp.theme, source.definitions);
-        lessPath = util.replaceExtension(file.path, '.less');
+        lessPath = replaceExt(file.path, '.less');
       }
       else if(isSiteTheme) {
         console.log('Change detected in site theme');
         lessPath = lessPath.replace(source.site, source.definitions);
-        lessPath = util.replaceExtension(file.path, '.less');
+        lessPath = replaceExt(file.path, '.less');
       }
       else if(isDefinition) {
         console.log('Change detected in definition');
-        lessPath = util.replaceExtension(file.path, '.less');
+        lessPath = replaceExt(file.path, '.less');
       }
 
       /*--------------

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -21,7 +21,7 @@ var
   rename       = require('gulp-rename'),
   replace      = require('gulp-replace'),
   uglify       = require('gulp-uglify'),
-  util         = require('gulp-util'),
+  replaceExt   = require('replace-ext'),
   watch        = require('gulp-watch'),
 
   // user config
@@ -119,12 +119,12 @@ module.exports = function(callback) {
       }
       else if(isPackagedTheme) {
         console.log('Change detected in packaged theme');
-        lessPath = util.replaceExtension(file.path, '.less');
+        lessPath = replaceExt(file.path, '.less');
         lessPath = lessPath.replace(tasks.regExp.theme, source.definitions);
       }
       else if(isSiteTheme) {
         console.log('Change detected in site theme');
-        lessPath = util.replaceExtension(file.path, '.less');
+        lessPath = replaceExt(file.path, '.less');
         lessPath = lessPath.replace(source.site, source.definitions);
       }
       else {


### PR DESCRIPTION

### Closed Issues
#6063
### Description
Replace deprecated module `gulp-util` with official replacement `replace-ext`.
Also removes unused variable `util` from `tasks/admin/components/create.js`


References:
- https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
- https://github.com/gulpjs/gulp-util/issues/143
