### PR TITLE
Fix #5991. Icon color overrides by list.

### DIFF
--- a/src/definitions/elements/list.less
+++ b/src/definitions/elements/list.less
@@ -202,8 +202,8 @@ ol.ui.list ol li,
 }
 
 /* Linked Item Icons */
-.ui.list .list > a.item i.icon,
-.ui.list > a.item i.icon {
+.ui.list .list > a.item > i.icon,
+.ui.list > a.item > i.icon {
   color: @itemLinkIconColor;
 }
 
@@ -213,8 +213,8 @@ ol.ui.list ol li,
   cursor: pointer;
   color: @itemHeaderLinkColor !important;
 }
-.ui.list .list > .item a.header:hover,
-.ui.list > .item a.header:hover {
+.ui.list .list > .item > a.header:hover,
+.ui.list > .item > a.header:hover {
   color: @itemHeaderLinkHoverColor !important;
 }
 
@@ -344,8 +344,8 @@ ol.ui.list ol li,
         Hover
 --------------------*/
 
-.ui.list .list > a.item:hover .icon,
-.ui.list > a.item:hover .icon {
+.ui.list .list > a.item:hover > .icon,
+.ui.list > a.item:hover > .icon {
   color: @itemLinkIconHoverColor;
 }
 


### PR DESCRIPTION
Demo: https://semantic-ui-label-icon-color-lkymtasclt.now.sh/

In this pr list overrides icons colors only one level deep.