### PR TITLE
[Button] Center button text in fluid & vertically aligned button group

### DIFF
--- a/src/definitions/elements/button.less
+++ b/src/definitions/elements/button.less
@@ -1194,7 +1194,8 @@
 .ui.fluid.vertical.buttons,
 .ui.fluid.vertical.buttons > .button {
   display: flex;
-  width: auto;
+  width: 100%;
+  justify-content: center;
 }
 
 .ui.two.vertical.buttons > .button {


### PR DESCRIPTION
### Closed Issues

#6065 

### Description

Previously, Buttons in a `.ui.fluid.vertical.buttons` wouldn't take up the full width of the button group & thus the text wouldn't appear center-aligned. This fixes that by making them `width: 100%` and `justify-content: center`

### Testcase

[Before](https://jsfiddle.net/peaoswpm/1/)

[Fixed](https://jsfiddle.net/tcmal/xgjjjrgw/)
