### PR TITLE
[Form] Add * required marker from the label itself

### DIFF
--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -670,7 +670,8 @@
 .ui.form .required.fields.grouped > label:after,
 .ui.form .required.field > label:after,
 .ui.form .required.fields:not(.grouped) > .field > .checkbox:after,
-.ui.form .required.field > .checkbox:after {
+.ui.form .required.field > .checkbox:after,
+.ui.form label.required:after {
   margin: @requiredMargin;
   content: @requiredContent;
   color: @requiredColor;
@@ -678,7 +679,8 @@
 
 .ui.form .required.fields:not(.grouped) > .field > label:after,
 .ui.form .required.fields.grouped > label:after,
-.ui.form .required.field > label:after {
+.ui.form .required.field > label:after,
+.ui.form label.required:after {
   display: inline-block;
   vertical-align: top;
 }


### PR DESCRIPTION
### Description and TestCase
Before this PR in order to have the red `*` the `required` class must be added to the parent `.field` of the label.

This works fine until i have this case https://jsfiddle.net/kcqg1tz5/4/

When dealing with radio i cannot add the * marker to the label with this text `Signup for newsletter` because it does not live within a `.field`.

Also putting the `.required` on the `.inline.fields` will add the marker to the radios label elements which is not what i want.

With this PR adding the `.required` to the `label` itself will add the marker to that label only

