### PR TITLE
Fix multiple modals incorrect positioning

### DIFF
--- a/src/definitions/modules/modal.js
+++ b/src/definitions/modules/modal.js
@@ -564,21 +564,7 @@ $.fn.modal = function(parameters) {
         },
 
         can: {
-          fit: function() {
-            var
-              contextHeight  = module.cache.contextHeight,
-              verticalCenter = module.cache.contextHeight / 2,
-              topOffset      = module.cache.topOffset,
-              scrollHeight   = module.cache.scrollHeight,
-              height         = module.cache.height,
-              paddingHeight  = settings.padding,
-              startPosition  = (verticalCenter + topOffset)
-            ;
-            return (scrollHeight > height)
-              ? (startPosition + scrollHeight + paddingHeight < contextHeight)
-              : (height + (paddingHeight * 2) < contextHeight)
-            ;
-          }
+          fit: function() { return false; } /* This might be removed */
         },
 
         is: {


### PR DESCRIPTION
### Issue Titles
[Modal] Multiple modals incorrect positioning

### Closed Issues
#6185 

### Description
I fixed the issue of overlapping modals by just forcing `can.fit()` return value to `false`.  This forces the library to always add the `scrolling` class to both body and modals, and have not found any problem so far. I've been using this fix for a couple of weeks and seems really easy to apply. As Flexbox is the new solution, I think this method could be removed in the future.
By the way, having the `scrolling` class doesn't give any visual difference but having the scrollbar when the containers height is exceeded.

Tested on Opera 52.0.2871.40 and Firefox 59.0.2. Tried up to 6 dialogs.
https://github.com/Semantic-Org/Semantic-UI/issues/6185#issuecomment-379834080

### Testcase
[Before]
https://jsfiddle.net/ca0rovs3/476/

[After]
https://jsfiddle.net/5r830cv8/2/

