### PR TITLE
[Form Validation] Fix validation when multiple fields has the same name (#6368)

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -1015,7 +1015,6 @@ $.fn.form = function(parameters) {
             var
               $field       = module.get.field(field.identifier),
               type         = rule.type,
-              value        = $field.val(),
               isValid      = true,
               ancillary    = module.get.ancillaryValue(rule),
               ruleName     = module.get.ruleName(rule),
@@ -1025,12 +1024,20 @@ $.fn.form = function(parameters) {
               module.error(error.noRule, ruleName);
               return;
             }
-            // cast to string avoiding encoding special values
-            value = (value === undefined || value === '' || value === null)
-              ? ''
-              : $.trim(value + '')
-            ;
-            return ruleFunction.call($field, value, ancillary);
+            $.each($field, function(key, data) {
+              var
+                value = $(data).val()
+              ;
+              // cast to string avoiding encoding special values
+              value = (value === undefined || value === '' || value === null)
+                ? ''
+                : $.trim(value + '')
+              ;
+              if (!ruleFunction.call($field, value, ancillary)) {
+                isValid = false;
+              }
+            });
+            return isValid;
           }
         },
 


### PR DESCRIPTION
On multiple field with the same name (aka input array), the rule function test multiple times the first value instead of testing each value one time.

This PR allow correct testing of each input with the same name, which fixes #6368.