### PR TITLE
Added inverted option for grouped fields

### DIFF
--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -710,7 +710,8 @@
 .ui.inverted.form .inline.fields .field > label,
 .ui.inverted.form .inline.fields .field > p,
 .ui.inverted.form .inline.field > label,
-.ui.inverted.form .inline.field > p {
+.ui.inverted.form .inline.field > p,
+.ui.inverted.form .grouped.fields > label {
   color: @invertedLabelColor;
 }
 


### PR DESCRIPTION
Grouped fields will not displayed in white color, when they are in an inverted form