### PR TITLE
Right margin for .icons instead of its first child

### DIFF
--- a/src/definitions/elements/icon.less
+++ b/src/definitions/elements/icon.less
@@ -439,6 +439,7 @@ i.icons {
   display: inline-block;
   position: relative;
   line-height: 1;
+  margin-right: @distanceFromText;
 }
 
 i.icons .icon {
@@ -456,7 +457,6 @@ i.icons .icon:first-child {
   height: auto;
   vertical-align: top;
   transform: none;
-  margin-right: @distanceFromText;
 }
 
 /* Corner Icon */


### PR DESCRIPTION
When grouping icons (for example, placing a user icon inside big circle outline icon), right margin is applied to first child of .icons element, which makes the second icon shifted from center. I applied right margin to .icons itself.