### PR TITLE
[Dropdown] Selection should be announced to screenreader

### DIFF
--- a/src/definitions/modules/dropdown.js
+++ b/src/definitions/modules/dropdown.js
@@ -3873,16 +3873,16 @@ $.fn.dropdown.settings.templates = {
     ;
     html +=  '<i class="dropdown icon"></i>';
     if(select.placeholder) {
-      html += '<div class="default text">' + placeholder + '</div>';
+      html += '<div class="default text" aria-live="assertive">' + placeholder + '</div>';
     }
     else {
-      html += '<div class="text"></div>';
+      html += '<div class="text" aria-live="assertive"></div>';
     }
-    html += '<div class="menu">';
+    html += '<div class="menu" role="listbox">';
     $.each(select.values, function(index, option) {
       html += (option.disabled)
-        ? '<div class="disabled item" data-value="' + option.value + '">' + option.name + '</div>'
-        : '<div class="item" data-value="' + option.value + '">' + option.name + '</div>'
+        ? '<div role="option" disabled class="disabled item" data-value="' + option.value + '">' + option.name + '</div>'
+        : '<div role="option" class="item" data-value="' + option.value + '">' + option.name + '</div>'
       ;
     });
     html += '</div>';


### PR DESCRIPTION
made div holding current selection a live region so the selection is announced by screenreader. Would also live to label the created input that precedes it on search/select component (wherever that may be), which is currently silent and misleads the user.

✖ Multiple features in one PR
✖ New Components Unless Previously Discussed with Maintainers (Consider creating separate repo, I'll link out to you)

✔ Add comments to complex/confusing code in "code" view of PR
✔ BUGS → This form is required:
✔ Enhancements → Only specific enhancements with detailed descriptions.

### Issue Titles

Use the format: [Component] Adds Support for Thing

For example: [Build Tools] Adds Source Map Support
Or: [Button] Fixes Inheritance for Red Basic Active State

### Closed Issues
#222 #333 #444

### Description

### Testcase

[Show before with this fiddle]
https://jsfiddle.net/ca0rovs3/

[Consider showing "fixed" case with your fiddle]()

You can link to your JS using https://rawgit.com/

