### PR TITLE
A segment in loading state should have a minimum height

### DIFF
--- a/src/definitions/elements/segment.less
+++ b/src/definitions/elements/segment.less
@@ -415,6 +415,7 @@
   text-shadow: none !important;
   color: transparent !important;
   transition: all 0s linear;
+  min-height: @loaderSize * 1.5;
 }
 .ui.loading.segment:before {
   position: absolute;


### PR DESCRIPTION
### Description

The minimum height could be a factor of the @loaderSize in order for the spinner to appear within the segment rather than overflowing it when it's empty or too small.



### Testcase

https://jsfiddle.net/ymn8w4uv/

[fixed](https://jsfiddle.net/sw69ouac/1/)
