### PR TITLE
[Dropdown] Fixes unwanted text selection

### DIFF
--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -31,6 +31,7 @@
   transition: @transition;
 
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+  user-select: none;
 }
 
 /*******************************


### PR DESCRIPTION

### [Dropdown] Fixes unwanted text selection

### Closed Issues
None reported.

### Description
Text selection occurs when clicking the dropdown multiple times without leaving focus.
![dropdown-selection](https://user-images.githubusercontent.com/7448249/47018188-82664a80-d154-11e8-9a2c-92a3786ac838.gif)

### Testcase
[See dropdown example](https://semantic-ui.com/modules/dropdown.html)
Click the dropdown down caret icon multiple times. It is also easily reproduced with the 
inline dropdown.