### PR TITLE
Fixes the issue where gulp build was not building all css files #6622…

### DIFF
--- a/tasks/build/css.js
+++ b/tasks/build/css.js
@@ -79,12 +79,9 @@ module.exports = function(callback) {
     .pipe(flatten())
   ;
 
-  // two concurrent streams from same source to concat release
-  uncompressedStream = stream.pipe(clone());
-  compressedStream   = stream.pipe(clone());
-
   // uncompressed component css
-  uncompressedStream
+  uncompressedStream = stream
+    .pipe(clone())
     .pipe(plumber())
     .pipe(replace(assets.source, assets.uncompressed))
     .pipe(gulpif(config.hasPermission, chmod(config.permission)))
@@ -97,8 +94,8 @@ module.exports = function(callback) {
 
   // compressed component css
   compressedStream = stream
-    .pipe(plumber())
     .pipe(clone())
+    .pipe(plumber())
     .pipe(replace(assets.source, assets.compressed))
     .pipe(minifyCSS(settings.minify))
     .pipe(rename(settings.rename.minCSS))


### PR DESCRIPTION
### Issue Titles
[Build Tools] Fixes gulp build not building all css files

### Closed Issues
#6622 #6067 

### Description
Inside css.js gulp build file, `compressedStream` was set by piping `stream` to `clone()`. But later on, that variable was again set. It means that the initial` compressedStream` was left open, which caused backpressure and paused the original stream. As a result, all css files were not built. Solved the issue by removing the first open stream.
