### PR TITLE
[Horizontal List] - icon not inline

### DIFF
--- a/dist/components/list.css
+++ b/dist/components/list.css
@@ -306,6 +306,7 @@ ol.ui.list ol li,
 .ui.horizontal.list > .item > .icon + .content {
   float: none;
   display: inline-block;
+  width: auto;
 }
 
 


### PR DESCRIPTION
An icon is not aligned properly within a horizontal list: https://jsfiddle.net/306w5p7g/

Regression introduced with: https://github.com/Semantic-Org/Semantic-UI/commit/6f2e1a85a07c198d13866dd1135677aa64583d07 - sets `.content` width to 100%

Solution: overwrite `.content` width for `.horizontal.list` https://jsfiddle.net/Lk1n7gwh/