### PR TITLE
[Build Tools] The watch task never call his callback function 

### DIFF
--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -23,6 +23,7 @@ var
   uglify       = require('gulp-uglify'),
   replaceExt   = require('replace-ext'),
   watch        = require('gulp-watch'),
+  runSequence  = require('run-sequence'),
 
   // user config
   config       = require('./config/user'),


### PR DESCRIPTION
### Description

#### Problem

The `watch` task of the `Semantic UI` build tools accepts a `callback` function but never invoke it.

#### Use Case

Use an external gulp file and reload the browser with `browser-sync` when any `Semantic UI` code is updated.

Ex.

```
const browserSync = require("browser-sync");
const semanticWatch = require("./tasks/watch");

gulp.task("watch", ["serve"], () => {
    gulp.watch("index.html", ["refresh"]).on("change", reportChange);

    // HERE: use the accepted callback function to reload the browser.
    semanticWatch(() => browserSync.reload());
});
```



