### PR TITLE
HTML select size -- auto height

### DIFF
--- a/src/definitions/modules/dropdown.less
+++ b/src/definitions/modules/dropdown.less
@@ -384,6 +384,9 @@ select.ui.dropdown {
   border: @selectBorder;
   visibility: @selectVisibility;
 }
+select[size].ui.dropdown{
+  height:auto;
+}
 .ui.selection.dropdown > .search.icon,
 .ui.selection.dropdown > .delete.icon,
 .ui.selection.dropdown > .dropdown.icon {


### PR DESCRIPTION
fix issue #6178

to correctly display ... with javascript off
```
<select multiple size="2" class="ui dropdown">
    <option>1</option>
    <option>2</option>
</select>
```
