### PR TITLE
[Segment] Fix math bug with attached segments

### DIFF
--- a/src/themes/default/elements/segment.variables
+++ b/src/themes/default/elements/segment.variables
@@ -102,7 +102,7 @@
 /* Attached */
 @attachedTopOffset: 0px;
 @attachedBottomOffset: 0px;
-@attachedHorizontalOffset: -@borderWidth;
+@attachedHorizontalOffset: @borderWidth;
 @attachedWidth: calc(100% - (@attachedHorizontalOffset * 2));
 @attachedBoxShadow: none;
 @attachedBorder: @borderWidth solid @solidBorderColor;


### PR DESCRIPTION
### Closed Issues
#6763

### Description

The purpose of this pull request is to fix a math bug with attached segments which causes their `width` and `max-width` properties to exceed `100%`. See #6763 for more details.

### Testcase

Before test case: https://jsfiddle.net/notfunk/yax4qewz/2/

