### PR TITLE
[Theme] Add replace() to build proper encoded URL

### DIFF
--- a/src/themes/default/globals/site.variables
+++ b/src/themes/default/globals/site.variables
@@ -12,7 +12,7 @@
 @headerFont        : @fontName, 'Helvetica Neue', Arial, Helvetica, sans-serif;
 @pageFont          : @fontName, 'Helvetica Neue', Arial, Helvetica, sans-serif;
 
-@googleFontName    : @fontName;
+@googleFontName    : replace(@fontName, ' ', '+');
 @importGoogleFonts : true;
 @googleFontSizes   : '400,700,400italic,700italic';
 @googleSubset      : 'latin';


### PR DESCRIPTION
### Description

On Firefox and in the case where a font has spaces in the name (e.g. Roboto Slab), the import url for Google Fonts will not be valid and fonts may not load as expected.
