### PR TITLE
:bug: Fixes docs build error from Node's fs

### DIFF
--- a/tasks/docs/build.js
+++ b/tasks/docs/build.js
@@ -80,7 +80,10 @@ module.exports = function(callback) {
   gulp.src(config.paths.template.eco + globs.eco)
     .pipe(map(metadata.parser))
     .on('end', function() {
-      fs.writeFile(output.metadata + '/metadata.json', JSON.stringify(metadata.result, null, 2));
+      fs.writeFile(output.metadata + '/metadata.json', JSON.stringify(metadata.result, null, 2),
+        error => {
+          console.log("metadata failed", error);
+        });
     })
   ;
 


### PR DESCRIPTION
`fs` from Node now requires a callback for the third parameter, which was missing from the docs Gulp build task file, causing the `gulp build-docs` process to break with the following error:

```
[15:59:18] Starting 'build-docs'...
Building Metadata
Copying examples
Copying LESS source
Building Semantic for docs
(node:72733) [DEP0013] DeprecationWarning: Calling an asynchronous function without callback is deprecated.
fs.js:113
      throw err;  // Forgot a callback but don't know where? Use NODE_DEBUG=fs
      ^

Error: ENOENT: no such file or directory, open '/Users/username/Development/HTML/docs/out/metadata.json'
ITs-MacBook-Pro-6:ksc-ui photoroom$ ./node_modules/gulp/bin/gulp.js build-docs
```

Adding a simple error callback (with optional console log for error reporting) **fixes this issue**. Running the docs build process now works.

Not sure if this has already been hashed out for the next release cycle.

✖ Multiple features in one PR
✖ New Components Unless Previously Discussed with Maintainers (Consider creating separate repo, I'll link out to you)

✔ Add comments to complex/confusing code in "code" view of PR
✔ BUGS → This form is required:
✔ Enhancements → Only specific enhancements with detailed descriptions.

### Issue Titles

Use the format: [Component] Adds Support for Thing

For example: [Build Tools] Adds Source Map Support
Or: [Button] Fixes Inheritance for Red Basic Active State

### Closed Issues
#222 #333 #444

### Description

### Testcase

[Show before with this fiddle]
https://jsfiddle.net/ca0rovs3/

[Consider showing "fixed" case with your fiddle]()

You can link to your JS using https://rawgit.com/

