### PR TITLE
[Theme]: allow null @site

### DIFF
--- a/src/theme.less
+++ b/src/theme.less
@@ -16,7 +16,7 @@
 @import "@{themesFolder}/default/globals/site.variables";
 
 /* Packaged site.variables */
-@import "@{themesFolder}/@{site}/globals/site.variables";
+@import (optional) "@{themesFolder}/@{site}/globals/site.variables";
 
 /* Component's site.variables */
 @import (optional) "@{themesFolder}/@{theme}/globals/site.variables";


### PR DESCRIPTION
### [Theme]: allow null @site

allow "null" values for @site theme config variable, like all other variables already allow.
as the default theme is always imported, using "null" values for all variables decreases dramatically the bundle size by avoiding duplicates when using default theme. this improvement is noticeable even when using optimizers like cssnano.

ps: i am calling "null" values that cause the optional import not to find any file.