### PR TITLE
Remove pointer events for disabled toggle

### DIFF
--- a/src/definitions/modules/checkbox.less
+++ b/src/definitions/modules/checkbox.less
@@ -572,6 +572,11 @@
   background-color: @toggleOnFocusLaneColor !important;
 }
 
+/* Disabled */
+.ui.toggle.checkbox.disabled {
+  pointer-events: none;
+}
+
 /*******************************
             Variations
 *******************************/


### PR DESCRIPTION
Set pointer-events to none when checkbox is in toggle mode and is disabled

### Description

Came across this while developing a UI and didn't see any related issues.
A very simple update that just ensures when a checkbox is in toggle mode and is also disabled, the toggle cannot be manipulated.