### PR TITLE
[Form] Fixes "remove rule(field)" throw exception if field has no rules

### DIFF
--- a/src/definitions/behaviors/form.js
+++ b/src/definitions/behaviors/form.js
@@ -749,19 +749,19 @@ $.fn.form = function(parameters) {
 
         remove: {
           rule: function(field, rule) {
-            var
-              rules = $.isArray(rule)
-                ? rule
-                : [rule]
-            ;
+            if(validation[field] == undefined || !$.isArray(validation[field].rules)) {
+              return;
+            }
             if(rule == undefined) {
               module.debug('Removed all rules');
               validation[field].rules = [];
               return;
             }
-            if(validation[field] == undefined || !$.isArray(validation[field].rules)) {
-              return;
-            }
+            var
+              rules = $.isArray(rule)
+                ? rule
+                : [rule]
+            ;
             $.each(validation[field].rules, function(index, rule) {
               if(rules.indexOf(rule.type) !== -1) {
                 module.debug('Removed rule', rule.type);


### PR DESCRIPTION
### Closed Issues
#5745

### Description
`remove rule(field, rules)` should remove all rules when argument `rules` is omitted. But `field` may not have any rules, and it would raise exceptions because of `validation[field].rules = []`.

There is some guard code to check if `validation[field].rules` exists, but the order is wrong apparently. 

### Testcase
https://jsfiddle.net/whd3o60j/3/

Click "Remove All Validations", raised exception `Uncaught TypeError: Cannot set property 'rules' of undefined` (in Chrome)
