### PR TITLE
Typo fix based on documentation specifications

### DIFF
--- a/src/definitions/modules/search.js
+++ b/src/definitions/modules/search.js
@@ -1295,7 +1295,7 @@ $.fn.search.settings = {
     pressed   : 'down'
   },
 
-  error : {
+  errors : {
     source          : 'Cannot search. No source used, and Semantic API module was not included',
     noResults       : 'Your search returned no results',
     logging         : 'Error in debug logging, exiting.',


### PR DESCRIPTION
### Issue Titles

[Search] Fixed type

### Description

In the documentation it specifies 'errors' but in the code it was 'error'

