### PR TITLE
[Build Tools] Report errors in theme.less that are not on lines 5 or 46

### DIFF
--- a/tasks/config/tasks.js
+++ b/tasks/config/tasks.js
@@ -100,11 +100,12 @@ module.exports = {
                 console.error('Missing theme.config value for ', element);
               }
               console.error('Most likely new UI was added in an update. You will need to add missing elements from theme.config.example');
-            }
-            if(error.line == 46) {
+            } else if(error.line == 46) {
               element = regExp.element.exec(error.message)[1];
               theme   = regExp.theme.exec(error.message)[1];
               console.error(theme + ' is not an available theme for ' + element);
+            } else {
+              console.log(error);
             }
           }
           else {


### PR DESCRIPTION
### Closed Issues
#7004

### Description
Title says it all. Reports errors when a path is not found in theme.less due to overridden variable.
