### PR TITLE
[Icon] Fixed background issue when Icon is used as Labeled Icon for Button as loading one

### DIFF
--- a/src/definitions/elements/icon.less
+++ b/src/definitions/elements/icon.less
@@ -71,15 +71,19 @@ i.icon:before {
 i.icon.loading {
   height: 1em;
   line-height: 1;
+}
+
+i.icon.loading:before {
   animation: icon-loading @loadingDuration linear infinite;
 }
+
 @keyframes icon-loading {
- from {
-    transform: rotate(0deg);
- }
- to {
-    transform: rotate(360deg);
- }
+  from {
+    transform: translateY(-50%) rotate(0deg);
+  }
+  to {
+    transform: translateY(-50%) rotate(360deg);
+  }
 }
 
 /*******************************


### PR DESCRIPTION
### Description

See my initial issue https://github.com/Semantic-Org/Semantic-UI-React/issues/4088 

I moved `icon-loading` animation into `:before` element itself.

### Testcase

**Before**: https://jsfiddle.net/afkm1v7w/
**After**: https://jsfiddle.net/t16y3wLk/
(I demonstrated my changes in temporary CSS override) 

