### PR TITLE
now dropdown searches all words of a sentence provided by dropdown item

### DIFF
--- a/dist/components/dropdown.js
+++ b/dist/components/dropdown.js
@@ -788,7 +788,7 @@ $.fn.dropdown = function(parameters) {
               : module.get.query(),
             results          =  null,
             escapedTerm      = module.escape.string(searchTerm),
-            beginsWithRegExp = new RegExp('^' + escapedTerm, 'igm')
+            beginsWithRegExp = new RegExp(escapedTerm, 'igm')
           ;
           // avoid loop if we're matching nothing
           if( module.has.query() ) {


### PR DESCRIPTION
### Dropdown Search Functionality


[Dropdown] now dropdown searches all words of a sentence provided by dropdown item.

### Closed Issues
#7006 

### Description
Semantic Ui default search method in on first word of an item in dropdown. simply by removing "^" from the regex, dropdwon searches over all words of an item.

