### PR TITLE
[Accordion] Fixes margin invalid property value

### DIFF
--- a/src/themes/default/modules/accordion.variables
+++ b/src/themes/default/modules/accordion.variables
@@ -31,7 +31,7 @@
 @childAccordionPadding: 0em;
 
 /* Content */
-@contentMargin: '';
+@contentMargin: 0em;
 @contentPadding: 0.5em 0em 1em;
 
 /*-------------------


### PR DESCRIPTION
### Description

Since `margin: ''` is invalid. What about setting it to `0em`?
