### PR TITLE
[Form] Inverted grouped fields label

### DIFF
--- a/src/definitions/collections/form.less
+++ b/src/definitions/collections/form.less
@@ -706,6 +706,7 @@
 .ui.form .inverted.segment .ui.checkbox .box,
 .ui.inverted.form .ui.checkbox label,
 .ui.inverted.form .ui.checkbox .box,
+.ui.inverted.form .grouped.fields > label,
 .ui.inverted.form .inline.fields > label,
 .ui.inverted.form .inline.fields .field > label,
 .ui.inverted.form .inline.fields .field > p,


### PR DESCRIPTION
### [Form] Inverted grouped fields label

### Description
This pull request addresses an issue where labels within grouped fields were not inheriting the inverted color in an inverted form. 
Added .grouped.fields > label selector for targeted styling.

### Testcase

[Show before with this fiddle]
https://jsfiddle.net/Festiis/8t6fgkjo/